### PR TITLE
Added Surfshark ASN to hosting detection

### DIFF
--- a/soup/netAs.cpp
+++ b/soup/netAs.cpp
@@ -95,6 +95,7 @@ namespace soup
 		case 140952: // Strong Technology, LLC
 		case 42473: // ANEXIA Internetdienstleistungs GmbH
 		case 59432: // GINERNET
+		case 209854: // Surfshark LTD.		
 			// Green Floid LLC
 		case 40622:
 		case 204957:


### PR DESCRIPTION
Example IP Address Lookup:

https://iphub.info/?ip=36.255.196.0