### PR TITLE
Add Server Plan ASN as Hosting

### DIFF
--- a/soup/netAs.cpp
+++ b/soup/netAs.cpp
@@ -98,6 +98,7 @@ namespace soup
 		case 43357: // Owl Limited
 		case 29802: // HIVELOCITY, Inc.
 		case 54994: // QUANTIL NETWORKS INC
+		case 52030: // Server Plan S.r.l.		
 			// Latitude.sh (formerly Maxihost)
 		case 262287:
 		case 396356:


### PR DESCRIPTION
More infos here:

https://www.peeringdb.com/net/28204

(it already gets detected by the "server" substring but will improve time and waste less resources to just find it from the ASN)