### PR TITLE
Add Shadow SAS to Hosting Detection

### DIFF
--- a/soup/netAs.cpp
+++ b/soup/netAs.cpp
@@ -98,6 +98,7 @@ namespace soup
 		case 43357: // Owl Limited
 		case 29802: // HIVELOCITY, Inc.
 		case 54994: // QUANTIL NETWORKS INC
+		case 64476: // Shadow SAS (shadow.tech)
 			// NForce Entertainment B.V.	
 		case 43350:
 		case 64437:	


### PR DESCRIPTION
More infos about Shadow SAS:
https://www.peeringdb.com/asn/64476
https://shadow.tech/

This Hosting is also used by GTA:O bots that spam about modded accounts in every lobby.

Example IP:
https://iphub.info/?ip=85.190.84.0