### PR TITLE
Ignore Scaleway as Hosting as it's actually a false positive

### DIFF
--- a/soup/netAs.cpp
+++ b/soup/netAs.cpp
@@ -151,7 +151,9 @@ namespace soup
 				&& slug.find("afrihost") == std::string::npos
 				)
 			|| slug.find("layer") != std::string::npos // AS49453, AS57172 Global Layer B.V.
-			|| slug.find("scale") != std::string::npos
+			|| (slug.find("scale") != std::string::npos
+				&& slug.find("scaleway") == std::string::npos
+				)
 			|| slug.find("server") != std::string::npos
 			|| slug.find("vps") != std::string::npos
 			|| slug.find("hetzner") != std::string::npos


### PR DESCRIPTION
Ignore Scaleway S.A.S. as it's not a hosting and apparently seems to be related to Iliad.
This detection triggered because of the filter "scale".

More infos about Scaleway S.A.S. :
https://ipinfo.io/AS29447/81.56.0.0/15-81.56.24.0/23
https://iphub.info/?ip=81.56.24.0