### PR TITLE
Add Strong Technology to Hosting Detection

### DIFF
--- a/soup/netAs.cpp
+++ b/soup/netAs.cpp
@@ -148,6 +148,11 @@ namespace soup
 			// Path Network, Inc
 		case 396998:
 		case 30644:
+			// Strong Technology
+		case 13926:
+		case 54203:
+		case 22781:
+		case 62651:
 			return true;
 		}
 		std::string slug = handle;


### PR DESCRIPTION
More infos about Strong Technology:

https://support.strongtech.org/hc/en-us

Also used by IPVanish:
https://ipinfo.io/173.245.203.158
https://iphub.info/?ip=173.245.203.158