### PR TITLE
Add Google One VPN ASN to Hosting detection

### DIFF
--- a/soup/netAs.cpp
+++ b/soup/netAs.cpp
@@ -153,6 +153,8 @@ namespace soup
 		case 54203:
 		case 22781:
 		case 62651:
+			// Google One VPN
+		case 36492:
 			return true;
 		}
 		std::string slug = handle;


### PR DESCRIPTION
As possible to see here: 
https://ipinfo.io/162.120.135.30

that ASN is used by Google LLC for Business/Hosting Purposes and already has been seen using it for VPNs... 

It got added to the bottom since we're probably going to have more of these Google ASNs in the future.