### PR TITLE
Update Madlions MAD68HE product ids

### DIFF
--- a/soup/AnalogueKeyboard.cpp
+++ b/soup/AnalogueKeyboard.cpp
@@ -169,7 +169,7 @@ NAMESPACE_SOUP
 				{
 					return "Madlions MAD60HE";
 				}
-				else if (hid.product_id == 0x1059 || hid.product_id == 0x105A || hid.product_id == 0x105C)
+				else if (hid.product_id == 0x1058 || hid.product_id == 0x1059 || hid.product_id == 0x105A || hid.product_id == 0x105C)
 				{
 					return "Madlions MAD68HE"; // Thanks to CaelTheColher for providing the layout
 				}


### PR DESCRIPTION
Same as AnalogSense/JavaScript-SDK#4, my version of the MAD68HE has a different product ID than the ones currently accounted for