### PR TITLE
AnalogueKeyboard: Add usage page to Lemokey check

### DIFF
--- a/soup/AnalogueKeyboard.cpp
+++ b/soup/AnalogueKeyboard.cpp
@@ -156,9 +156,12 @@ NAMESPACE_SOUP
 		}
 		else if (hid.vendor_id == 0x362D) // Lemokey
 		{
-			if (hid.product_id == 0x0610) // ANSI
+			if (hid.usage_page == 0xFF60 && hid.usage == 0x61)
 			{
-				return "Lemokey P1 HE"; // Thanks to Azarattum for providing the layout
+				if (hid.product_id == 0x0610) // ANSI
+				{
+					return "Lemokey P1 HE"; // Thanks to Azarattum for providing the layout
+				}
 			}
 		}
 		// NuPhy


### PR DESCRIPTION
I think this might help with https://github.com/AnalogSense/universal-analog-plugin/issues/1#issuecomment-2726223943 

Without a usage_page it detects two devices, one of which never responds and the program is stuck at `receiveReport`. Although I got the cli to recognize my keyboard now `Found Lemokey P1 HE, switching to analogue mode.`, I still didn't get any output in the `soup.exe keyboard` UI... Am I missing something? @Sainan, could you compile a `universal-analog-plugin` for Windows with this change, so I can test it there? I don't quite get how the Sun build system workds.