### PR TITLE
AnalogueKeyboard: Add Lemokey vendor_id to key polling

### DIFF
--- a/soup/AnalogueKeyboard.cpp
+++ b/soup/AnalogueKeyboard.cpp
@@ -522,7 +522,7 @@ NAMESPACE_SOUP
 		{
 			return getActiveKeysDrunkdeer();
 		}
-		else if (hid.vendor_id == 0x3434)
+		else if (hid.vendor_id == 0x3434 || hid.vendor_id == 0x362D)
 		{
 			return getActiveKeysKeychron();
 		}


### PR DESCRIPTION
Ah... So this was the final piece, why I was not getting any output. That makes sense. The `__assume(false)` compiler optimization confused me a lot, since I was getting Madlion packets to my keyboard because of it. Now `soup.exe keyboard` finally works!