### PR TITLE
Add Elias gamma coding support to bit streams

### DIFF
--- a/CLI/cli_test.cpp
+++ b/CLI/cli_test.cpp
@@ -1168,6 +1168,22 @@ static void unit_io()
 		bw.finishByte();
 		assert(w.data == "\x5F\x01");
 	});
+	test("Elias gamma", []
+	{
+		StringWriter w;
+		BitWriter bw(&w);
+		bw.u32_elias(0);
+		bw.u32_elias(1);
+		bw.u32_elias(10);
+		bw.finishByte();
+
+		StringReader r(std::move(w.data));
+		BitReader br(&r);
+		uint32_t v = 0;
+		assert(br.u32_elias(v) && v == 0);
+		assert(br.u32_elias(v) && v == 1);
+		assert(br.u32_elias(v) && v == 10);
+	});
 	test("StringRefReader", []
 	{
 		std::string s = "Hello\nWorld";

--- a/soup/BitReader.cpp
+++ b/soup/BitReader.cpp
@@ -207,6 +207,36 @@ NAMESPACE_SOUP
 		return false;
 	}
 
+	bool BitReader::u32_elias(uint32_t& val)
+	{
+		uint32_t zeros = 0;
+		bool bit;
+		while (true)
+		{
+			if (!b(bit))
+			{
+				return false;
+			}
+			if (bit)
+			{
+				break;
+			}
+			++zeros;
+		}
+
+		val = 1;
+		while (zeros--)
+		{
+			if (!b(bit))
+			{
+				return false;
+			}
+			val = (val << 1) | (bit ? 1u : 0u);
+		}
+		val -= 1;
+		return true;
+	}
+
 	bool BitReader::str_utf8_nt(std::string& str)
 	{
 		std::u32string tmp{};

--- a/soup/BitReader.hpp
+++ b/soup/BitReader.hpp
@@ -80,6 +80,7 @@ NAMESPACE_SOUP
 		[[deprecated]] bool u17_dyn_2(uint32_t& val); // A 17-bit value encoded using 5-19 bits. Assumes that smaller numbers are the norm.
 		/*[[deprecated]]*/ bool u20_dyn(uint32_t& val); // A 20-bit value encoded using 6-22 bits. Assumes that smaller numbers are the norm.
 		[[deprecated]] bool u32_dyn(uint32_t& val); // A 32-bit value encoded using 10-34 bits. Assumes that smaller numbers are the norm.
+		bool u32_elias(uint32_t& val); // A 32-bit value encoded using Elias gamma coding.
 		/*[[deprecated]]*/ bool str_utf8_nt(std::string& str); // A UTF-8 string encoded using 6-23 bits per codepoint. Null-terminated.
 		/*[[deprecated]]*/ bool str_utf32_nt(std::u32string& str); // A UTF-32 string encoded using 6-23 bits per codepoint. Null-terminated.
 		[[deprecated]] bool str_utf8_lp(std::string& str, uint8_t lpbits); // A UTF-8 string encoded using 6-23 bits per codepoint. Length-prefixed.

--- a/soup/BitWriter.cpp
+++ b/soup/BitWriter.cpp
@@ -170,6 +170,24 @@ NAMESPACE_SOUP
 			;
 	}
 
+	bool BitWriter::u32_elias(uint32_t val)
+	{
+		val += 1;
+		uint8_t bits = static_cast<uint8_t>(bitutil::getMostSignificantSetBit(val) + 1);
+		if (!t(bits - 1, 0))
+		{
+			return false;
+		}
+		for (int i = bits - 1; i >= 0; --i)
+		{
+			if (!b((val >> i) & 1))
+			{
+				return false;
+			}
+		}
+		return true;
+	}
+
 	bool BitWriter::str_utf8_nt(const std::string& str)
 	{
 		return str_utf32_nt(unicode::utf8_to_utf32(str));

--- a/soup/BitWriter.hpp
+++ b/soup/BitWriter.hpp
@@ -62,6 +62,7 @@ NAMESPACE_SOUP
 		[[deprecated]] bool u17_dyn_2(uint32_t val); // A 17-bit value encoded using 5-19 bits. Assumes that smaller numbers are the norm.
 		/*[[deprecated]]*/ bool u20_dyn(uint32_t val); // A 20-bit value encoded using 6-22 bits. Assumes that smaller numbers are the norm.
 		[[deprecated]] bool u32_dyn(uint32_t val); // A 32-bit value encoded using 10-34 bits. Assumes that smaller numbers are the norm.
+		bool u32_elias(uint32_t val); // A 32-bit value encoded using Elias gamma coding.
 		/*[[deprecated]]*/ bool str_utf8_nt(const std::string& str); // A UTF-8 string encoded using 6-23 bits per codepoint. Null-terminated.
 		/*[[deprecated]]*/ bool str_utf32_nt(const std::u32string& str); // A UTF-32 string encoded using 6-23 bits per codepoint. Null-terminated.
 		[[deprecated]] bool str_utf8_lp(const std::string& str, uint8_t lpbits); // A UTF-8 string encoded using 6-23 bits per codepoint. Length-prefixed.


### PR DESCRIPTION
## Summary
- extend `BitReader` and `BitWriter` with `u32_elias` for Elias gamma encoded integers
- add unit tests to verify round-trip encoding/decoding via Elias gamma

## Testing
- `./CLI/soup test`

------
https://chatgpt.com/codex/tasks/task_e_68992270b478832593ccb0755c824a4c