### PR TITLE
Add clang-format workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,9 @@
 BasedOnStyle: LLVM
-IndentWidth: 8
-TabWidth: 8
+IndentWidth: 4
+TabWidth: 4
 UseTab: ForIndentation
 BreakBeforeBraces: Allman
 ColumnLimit: 0
+SortIncludes: CaseInsensitive
+PointerAlignment: Left
 

--- a/.clang-format
+++ b/.clang-format
@@ -1,7 +1,7 @@
 BasedOnStyle: LLVM
 IndentWidth: 4
 TabWidth: 4
-UseTab: ForIndentation
+UseTab: Always
 BreakBeforeBraces: Allman
 ColumnLimit: 0
 SortIncludes: CaseInsensitive

--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,7 @@
+BasedOnStyle: LLVM
+IndentWidth: 8
+TabWidth: 8
+UseTab: ForIndentation
+BreakBeforeBraces: Allman
+ColumnLimit: 0
+

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,19 @@
+name: Clang Format
+
+on:
+  pull_request:
+    branches: [ "senpai" ]
+  push:
+    branches: [ "senpai" ]
+
+jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: DoozyX/clang-format-lint-action@v0.16
+        with:
+          source: "./"
+          extensions: "h,hpp,hxx,c,cc,cpp,cxx"
+          style: file
+          clangFormatVersion: 17

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - uses: DoozyX/clang-format-lint-action@v0.16
         with:
           source: "./"

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ If you want some ideas as to how start using Soup, check out [the docs](docs).
 If you're looking to use Soup from a language other than C++, have a look at [the bindings](https://github.com/calamity-inc/Soup/tree/senpai/bindings).
 
 ## Formatting
-
-To keep the code style consistent, run `clang-format` before committing changes.
-The following command formats all tracked C and C++ source files in-place:
+A `.clang-format` file captures the project's coding conventions.
+Run `clang-format` before committing changes. The following command formats all
+tracked C and C++ source files in-place using that configuration:
 
 ```bash
-clang-format -i $(git ls-files "*.h" "*.hpp" "*.hxx" "*.c" "*.cc" "*.cpp" "*.cxx")
+clang-format -style=file -i $(git ls-files "*.h" "*.hpp" "*.hxx" "*.c" "*.cc" "*.cpp" "*.cxx")
 ```
 
-Make sure `clang-format` version 17 or newer is installed so it matches the
-version used in continuous integration.
+Use `clang-format` version 17 to match the version used in continuous
+integration.

--- a/README.md
+++ b/README.md
@@ -33,3 +33,15 @@ For WASM, it can be done via `php wasm.php` (in the root folder) or `sun wasm` (
 If you want some ideas as to how start using Soup, check out [the docs](docs).
 
 If you're looking to use Soup from a language other than C++, have a look at [the bindings](https://github.com/calamity-inc/Soup/tree/senpai/bindings).
+
+## Formatting
+
+To keep the code style consistent, run `clang-format` before committing changes.
+The following command formats all tracked C and C++ source files in-place:
+
+```bash
+clang-format -i $(git ls-files "*.h" "*.hpp" "*.hxx" "*.c" "*.cc" "*.cpp" "*.cxx")
+```
+
+Make sure `clang-format` version 17 or newer is installed so it matches the
+version used in continuous integration.


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow that runs clang-format via DoozyX/clang-format-lint-action on pushes and pull requests to `senpai`

## Testing
- `yamllint .github/workflows/clang-format.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*


------
https://chatgpt.com/codex/tasks/task_e_689925d932bc8325b796f053720eec9a