### PR TITLE
Add HKDF methods to CryptoHashAlgo

### DIFF
--- a/CLI/cli_test.cpp
+++ b/CLI/cli_test.cpp
@@ -241,6 +241,104 @@ static void unit_crypto()
 		assert(gen.getValue(9) == 520489);
 	});
 
+	test("hkdf", []
+	{
+		{
+			auto ikm = string::hex2bin("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+			auto salt = string::hex2bin("000102030405060708090a0b0c");
+			auto info = string::hex2bin("f0f1f2f3f4f5f6f7f8f9");
+			auto prk = sha256::hkdf_extract(salt, ikm);
+			assert(prk == string::hex2bin("077709362c2e32df0ddc3f0dc47bba6390b6c73bb50f9c3122ec844ad7c2b3e5"));
+			auto okm = sha256::hkdf_expand(prk, info, 42);
+			assert(okm == string::hex2bin("3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865"));
+			assert(sha256::hkdf(salt, ikm, info, 42) == okm);
+		}
+		{
+			auto ikm = string::hex2bin(
+				"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+				"202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+				"404142434445464748494a4b4c4d4e4f");
+			auto salt = string::hex2bin(
+				"606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+				"808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
+				"a0a1a2a3a4a5a6a7a8a9aaabacadaeaf");
+			auto info = string::hex2bin(
+				"b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
+				"d0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeef"
+				"f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
+			auto prk = sha256::hkdf_extract(salt, ikm);
+			assert(prk == string::hex2bin("06a6b88c5853361a06104c9ceb35b45cef760014904671014a193f40c15fc244"));
+			auto okm = sha256::hkdf_expand(prk, info, 82);
+			assert(okm == string::hex2bin(
+				"b11e398dc80327a1c8e7f78c596a49344f012eda2d4efad8a050cc4c19afa97c"
+				"59045a99cac7827271cb41c65e590e09da3275600c2f09b8367793a9aca3db71"
+				"cc30c58179ec3e87c14c01d5c1f3434f1d87"));
+			assert(sha256::hkdf(salt, ikm, info, 82) == okm);
+		}
+		{
+			auto ikm = string::hex2bin("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+			std::string salt;
+			std::string info;
+			auto prk = sha256::hkdf_extract(salt, ikm);
+			assert(prk == string::hex2bin("19ef24a32c717b167f33a91d6f648bdf96596776afdb6377ac434c1c293ccb04"));
+			auto okm = sha256::hkdf_expand(prk, info, 42);
+			assert(okm == string::hex2bin("8da4e775a563c18f715f802a063c5a31b8a11f5c5ee1879ec3454e5f3c738d2d9d201395faa4b61a96c8"));
+			assert(sha256::hkdf(salt, ikm, info, 42) == okm);
+		}
+		{
+			auto ikm = string::hex2bin("0b0b0b0b0b0b0b0b0b0b0b");
+			auto salt = string::hex2bin("000102030405060708090a0b0c");
+			auto info = string::hex2bin("f0f1f2f3f4f5f6f7f8f9");
+			auto prk = sha1::hkdf_extract(salt, ikm);
+			assert(prk == string::hex2bin("9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243"));
+			auto okm = sha1::hkdf_expand(prk, info, 42);
+			assert(okm == string::hex2bin("085a01ea1b10f36933068b56efa5ad81a4f14b822f5b091568a9cdd4f155fda2c22e422478d305f3f896"));
+			assert(sha1::hkdf(salt, ikm, info, 42) == okm);
+		}
+		{
+			auto ikm = string::hex2bin(
+				"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+				"202122232425262728292a2b2c2d2e2f303132333435363738393a3b3c3d3e3f"
+				"404142434445464748494a4b4c4d4e4f");
+			auto salt = string::hex2bin(
+				"606162636465666768696a6b6c6d6e6f707172737475767778797a7b7c7d7e7f"
+				"808182838485868788898a8b8c8d8e8f909192939495969798999a9b9c9d9e9f"
+				"a0a1a2a3a4a5a6a7a8a9aaabacadaeaf");
+			auto info = string::hex2bin(
+				"b0b1b2b3b4b5b6b7b8b9babbbcbdbebfc0c1c2c3c4c5c6c7c8c9cacbcccdcecf"
+				"d0d1d2d3d4d5d6d7d8d9dadbdcdddedfe0e1e2e3e4e5e6e7e8e9eaebecedeeef"
+				"f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff");
+			auto prk = sha1::hkdf_extract(salt, ikm);
+			assert(prk == string::hex2bin("8adae09a2a307059478d309b26c4115a224cfaf6"));
+			auto okm = sha1::hkdf_expand(prk, info, 82);
+			assert(okm == string::hex2bin(
+				"0bd770a74d1160f7c9f12cd5912a06ebff6adcae899d92191fe4305673ba2ffe"
+				"8fa3f1a4e5ad79f3f334b3b202b2173c486ea37ce3d397ed034c7f9dfeb15c5e"
+				"927336d0441f4c4300e2cff0d0900b52d3b4"));
+			assert(sha1::hkdf(salt, ikm, info, 82) == okm);
+		}
+		{
+			auto ikm = string::hex2bin("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+			std::string salt;
+			std::string info;
+			auto prk = sha1::hkdf_extract(salt, ikm);
+			assert(prk == string::hex2bin("da8c8a73c7fa77288ec6f5e7c297786aa0d32d01"));
+			auto okm = sha1::hkdf_expand(prk, info, 42);
+			assert(okm == string::hex2bin("0ac1af7002b3d761d1e55298da9d0506b9ae52057220a306e07b6b87e8df21d0ea00033de03984d34918"));
+			assert(sha1::hkdf(salt, ikm, info, 42) == okm);
+		}
+		{
+			auto ikm = string::hex2bin("0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c");
+			std::string salt;
+			std::string info;
+			auto prk = sha1::hkdf_extract(salt, ikm);
+			assert(prk == string::hex2bin("2adccada18779e7c2077ad2eb19d3f3e731385dd"));
+			auto okm = sha1::hkdf_expand(prk, info, 42);
+			assert(okm == string::hex2bin("2c91117204d745f3500d636a62f64f0ab3bae548aa53d423b0d1f27ebba6f5e5673a081d70cce7acfc48"));
+			assert(sha1::hkdf(salt, ikm, info, 42) == okm);
+		}
+	});
+
 	test("rsa", []
 	{
 		RsaKeypair kp(


### PR DESCRIPTION
## Summary
- add hkdf_extract and hkdf_expand helpers for deriving keys via HKDF (RFC 5869)
- expose hkdf convenience wrapper in CryptoHashAlgo

## Testing
- `php build_lib.php`

------
https://chatgpt.com/codex/tasks/task_e_68a8e4d8a6dc8325b1eed8e4f29ee422