### PR TITLE
Add macOS support to hwHid

### DIFF
--- a/build_common.php
+++ b/build_common.php
@@ -14,14 +14,14 @@ else
 $clanglink = $clang;
 if (!defined("PHP_WINDOWS_VERSION_MAJOR"))
 {
-	if (PHP_OS_FAMILY == "Darwin")
-	{
-		$clanglink .= " -lc++";
-	}
-	else
-	{
-		$clanglink .= " -lstdc++";
-	}
+        if (PHP_OS_FAMILY == "Darwin")
+        {
+                $clanglink .= " -lc++ -framework IOKit -framework CoreFoundation";
+        }
+        else
+        {
+                $clanglink .= " -lstdc++";
+        }
 	$clanglink .= " -pthread -lm -ldl";
 	if (!getenv("ANDROID_ROOT"))
 	{

--- a/build_common.php
+++ b/build_common.php
@@ -14,14 +14,14 @@ else
 $clanglink = $clang;
 if (!defined("PHP_WINDOWS_VERSION_MAJOR"))
 {
-        if (PHP_OS_FAMILY == "Darwin")
-        {
-                $clanglink .= " -lc++ -framework IOKit -framework CoreFoundation";
-        }
-        else
-        {
-                $clanglink .= " -lstdc++";
-        }
+	if (PHP_OS_FAMILY == "Darwin")
+	{
+		$clanglink .= " -lc++ -framework IOKit -framework CoreFoundation";
+	}
+	else
+	{
+		$clanglink .= " -lstdc++";
+	}
 	$clanglink .= " -pthread -lm -ldl";
 	if (!getenv("ANDROID_ROOT"))
 	{

--- a/soup/hwHid.cpp
+++ b/soup/hwHid.cpp
@@ -53,6 +53,11 @@ using udev_device_get_parent_with_subsystem_devtype_t = udev_device*(*)(udev_dev
 using udev_device_get_sysattr_value_t = const char*(*)(udev_device*, const char*);
 
 #define udev_list_entry_foreach(list_entry, first_entry) for (list_entry = first_entry; list_entry; list_entry = udev_list_entry_get_next(list_entry))
+#elif SOUP_MACOS
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/hid/IOHIDManager.h>
+#include <IOKit/hid/IOHIDKeys.h>
+#include <IOKit/IOKitLib.h>
 #endif
 
 NAMESPACE_SOUP
@@ -234,11 +239,11 @@ NAMESPACE_SOUP
 		use_udev_func(udev_device_get_parent_with_subsystem_devtype);
 		use_udev_func(udev_device_get_sysattr_value);
 
-		if (udev* udev = udev_new())
-		{
-			udev_enumerate* enumerate = udev_enumerate_new(udev);
-			udev_enumerate_add_match_subsystem(enumerate, "hidraw");
-			udev_enumerate_scan_devices(enumerate);
+                if (udev* udev = udev_new())
+                {
+                        udev_enumerate* enumerate = udev_enumerate_new(udev);
+                        udev_enumerate_add_match_subsystem(enumerate, "hidraw");
+                        udev_enumerate_scan_devices(enumerate);
 
 			udev_list_entry* devices;
 			devices = udev_enumerate_get_list_entry(enumerate);
@@ -287,12 +292,111 @@ NAMESPACE_SOUP
 				}
 			}
 
-			udev_enumerate_unref(enumerate);
-			udev_unref(udev);
-		}
+                        udev_enumerate_unref(enumerate);
+                        udev_unref(udev);
+                }
+#elif SOUP_MACOS
+                IOHIDManagerRef manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+                if (manager)
+                {
+                        IOHIDManagerSetDeviceMatching(manager, NULL);
+                        IOHIDManagerOpen(manager, kIOHIDOptionsTypeNone);
+                        CFSetRef device_set = IOHIDManagerCopyDevices(manager);
+                        if (device_set)
+                        {
+                                CFIndex num = CFSetGetCount(device_set);
+                                std::vector<IOHIDDeviceRef> devices(num);
+                                CFSetGetValues(device_set, (const void**)devices.data());
+                                for (CFIndex i = 0; i < num; ++i)
+                                {
+                                        IOHIDDeviceRef dev = devices[i];
+                                        hwHid hid{};
+
+                                        if (io_registry_entry_t entry = IOHIDDeviceGetService(dev))
+                                        {
+                                                io_string_t path;
+                                                if (IORegistryEntryGetPath(entry, kIOServicePlane, path) == KERN_SUCCESS)
+                                                {
+                                                        hid.path = path;
+                                                }
+                                        }
+
+                                        int32_t vid = 0, pid = 0, usage_page = 0, usage = 0;
+                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDVendorIDKey)), kCFNumberSInt32Type, &vid);
+                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDProductIDKey)), kCFNumberSInt32Type, &pid);
+                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDPrimaryUsagePageKey)), kCFNumberSInt32Type, &usage_page);
+                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDPrimaryUsageKey)), kCFNumberSInt32Type, &usage);
+                                        hid.vendor_id = static_cast<uint16_t>(vid);
+                                        hid.product_id = static_cast<uint16_t>(pid);
+                                        hid.usage_page = static_cast<uint16_t>(usage_page);
+                                        hid.usage = static_cast<uint16_t>(usage);
+
+                                        int32_t in_sz = 0, out_sz = 0, feat_sz = 0;
+                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxInputReportSizeKey)), kCFNumberSInt32Type, &in_sz);
+                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxOutputReportSizeKey)), kCFNumberSInt32Type, &out_sz);
+                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxFeatureReportSizeKey)), kCFNumberSInt32Type, &feat_sz);
+                                        hid.input_report_byte_length = static_cast<uint16_t>(in_sz);
+                                        hid.output_report_byte_length = static_cast<uint16_t>(out_sz);
+                                        hid.feature_report_byte_length = static_cast<uint16_t>(feat_sz);
+
+                                        if (CFStringRef transport = (CFStringRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDTransportKey)))
+                                        {
+                                                hid.is_bluetooth = (CFStringCompare(transport, CFSTR("Bluetooth"), 0) == kCFCompareEqualTo);
+                                        }
+
+                                        if (CFStringRef manu = (CFStringRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDManufacturerKey)))
+                                        {
+                                                char buf[256];
+                                                if (CFStringGetCString(manu, buf, sizeof(buf), kCFStringEncodingUTF8))
+                                                {
+                                                        hid.manufacturer_name = buf;
+                                                }
+                                        }
+                                        if (CFStringRef prod = (CFStringRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDProductKey)))
+                                        {
+                                                char buf[256];
+                                                if (CFStringGetCString(prod, buf, sizeof(buf), kCFStringEncodingUTF8))
+                                                {
+                                                        hid.product_name = buf;
+                                                }
+                                        }
+                                        if (CFStringRef serial = (CFStringRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDSerialNumberKey)))
+                                        {
+                                                char buf[256];
+                                                if (CFStringGetCString(serial, buf, sizeof(buf), kCFStringEncodingUTF8))
+                                                {
+                                                        hid.serial_number = buf;
+                                                }
+                                        }
+
+                                        if (CFDataRef desc = (CFDataRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDReportDescriptorKey)))
+                                        {
+                                                const UInt8* data = CFDataGetBytePtr(desc);
+                                                CFIndex len = CFDataGetLength(desc);
+                                                auto rd = HidReportDescriptor::parse((const char*)data, len);
+                                                hid.report_ids = std::move(rd.report_ids);
+                                                if (!in_sz) hid.input_report_byte_length = rd.input_report_byte_length;
+                                                if (!out_sz) hid.output_report_byte_length = rd.output_report_byte_length;
+                                                if (!feat_sz) hid.feature_report_byte_length = rd.feature_report_byte_length;
+                                        }
+
+                                        if (IOHIDDeviceOpen(dev, kIOHIDOptionsTypeNone) == kIOReturnSuccess)
+                                        {
+                                                CFRetain(dev);
+                                                hid.device = dev;
+                                        }
+
+                                        hid.read_buffer.reserve(hid.input_report_byte_length < 1024 ? 1024 : hid.input_report_byte_length);
+                                        res.emplace_back(std::move(hid));
+                                }
+                                CFRelease(device_set);
+                        }
+                        IOHIDManagerClose(manager, kIOHIDOptionsTypeNone);
+                        CFRelease(manager);
+                }
 #endif
-		return res;
-	}
+                return res;
+        }
 
 #if SOUP_WINDOWS
 	std::string hwHid::getManufacturerName() const
@@ -360,17 +464,26 @@ NAMESPACE_SOUP
 			HidD_FreePreparsedData(pp_data);
 		}
 #elif SOUP_LINUX
-		if (report_id == 0)
-		{
-			ret = report_ids.empty();
-		}
-		else
-		{
-			ret = report_ids.count(report_id) != 0;
-		}
+                if (report_id == 0)
+                {
+                        ret = report_ids.empty();
+                }
+                else
+                {
+                        ret = report_ids.count(report_id) != 0;
+                }
+#elif SOUP_MACOS
+                if (report_id == 0)
+                {
+                        ret = report_ids.empty();
+                }
+                else
+                {
+                        ret = report_ids.count(report_id) != 0;
+                }
 #endif
-		return ret;
-	}
+                return ret;
+        }
 
 	bool hwHid::hasReport() noexcept
 	{
@@ -384,15 +497,17 @@ NAMESPACE_SOUP
 			|| disconnected
 			;
 #elif SOUP_LINUX
-		pollfd pfd;
-		pfd.fd = handle;
-		pfd.events = POLLIN;
-		pfd.revents = 0;
-		return poll(&pfd, 1, 0) != 0;
+                pollfd pfd;
+                pfd.fd = handle;
+                pfd.events = POLLIN;
+                pfd.revents = 0;
+                return poll(&pfd, 1, 0) != 0;
+#elif SOUP_MACOS
+                return true;
 #else
-		return true;
+                return true;
 #endif
-	}
+        }
 
 #if SOUP_LINUX
 	static bool setup_sig_handler = false;
@@ -411,22 +526,32 @@ NAMESPACE_SOUP
 			read_buffer.erase(0, 1);
 		}
 #elif SOUP_LINUX
-		if (!setup_sig_handler)
-		{
-			signal::handle(SIGUSR1, [](int)
-			{
-				killed_via_signal = true;
-			});
-		}
-		killed_via_signal = false;
-		read_thrd = pthread_self();
-		reading = true;
-		int bytes_read = ::read(handle, read_buffer.data(), read_buffer.capacity());
-		reading = false;
-		read_buffer.resize(bytes_read < 0 ? 0 : bytes_read);
+                if (!setup_sig_handler)
+                {
+                        signal::handle(SIGUSR1, [](int)
+                        {
+                                killed_via_signal = true;
+                        });
+                }
+                killed_via_signal = false;
+                read_thrd = pthread_self();
+                reading = true;
+                int bytes_read = ::read(handle, read_buffer.data(), read_buffer.capacity());
+                reading = false;
+                read_buffer.resize(bytes_read < 0 ? 0 : bytes_read);
+#elif SOUP_MACOS
+                CFIndex len = input_report_byte_length;
+                if (len == 0)
+                {
+                        len = 64;
+                }
+                read_buffer.resize(len);
+                IOHIDDeviceRef dev = (IOHIDDeviceRef)device;
+                IOReturn r = IOHIDDeviceGetReport(dev, kIOHIDReportTypeInput, 0, (uint8_t*)read_buffer.data(), &len);
+                read_buffer.resize(r == kIOReturnSuccess ? len : 0);
 #endif
-		return read_buffer;
-	}
+                return read_buffer;
+        }
 
 	const Buffer<>& hwHid::receiveReport(uint8_t& out_report_id) noexcept
 	{
@@ -439,15 +564,22 @@ NAMESPACE_SOUP
 			read_buffer.erase(0, 1);
 		}
 #elif SOUP_LINUX
-		SOUP_UNUSED(receiveReport());
-		if (!report_ids.empty())
-		{
-			out_report_id = read_buffer.at(0);
-			read_buffer.erase(0, 1);
-		}
+                SOUP_UNUSED(receiveReport());
+                if (!report_ids.empty())
+                {
+                        out_report_id = read_buffer.at(0);
+                        read_buffer.erase(0, 1);
+                }
+#elif SOUP_MACOS
+                SOUP_UNUSED(receiveReport());
+                if (!report_ids.empty())
+                {
+                        out_report_id = read_buffer.at(0);
+                        read_buffer.erase(0, 1);
+                }
 #endif
-		return read_buffer;
-	}
+                return read_buffer;
+        }
 
 	// URB_INTERRUPT in
 	const Buffer<>& hwHid::receiveReportWithReportId() noexcept
@@ -469,14 +601,20 @@ NAMESPACE_SOUP
 		}
 		read_buffer.resize(bytes_read);
 #elif SOUP_LINUX
-		SOUP_UNUSED(receiveReport());
-		if (report_ids.empty())
-		{
-			read_buffer.insert_front(1, 0);
-		}
+                SOUP_UNUSED(receiveReport());
+                if (report_ids.empty())
+                {
+                        read_buffer.insert_front(1, 0);
+                }
+#elif SOUP_MACOS
+                SOUP_UNUSED(receiveReport());
+                if (report_ids.empty())
+                {
+                        read_buffer.insert_front(1, 0);
+                }
 #endif
-		return read_buffer;
-	}
+                return read_buffer;
+        }
 
 	// URB_INTERRUPT in
 	const Buffer<>& hwHid::receiveReportWithoutReportId() noexcept
@@ -488,16 +626,24 @@ NAMESPACE_SOUP
 			read_buffer.erase(0, 1);
 		}
 #elif SOUP_LINUX
-		SOUP_UNUSED(receiveReport());
-		if (input_report_byte_length != 0
-			&& !report_ids.empty()
-			)
-		{
-			read_buffer.erase(0, 1);
-		}
+                SOUP_UNUSED(receiveReport());
+                if (input_report_byte_length != 0
+                        && !report_ids.empty()
+                        )
+                {
+                        read_buffer.erase(0, 1);
+                }
+#elif SOUP_MACOS
+                SOUP_UNUSED(receiveReport());
+                if (input_report_byte_length != 0
+                        && !report_ids.empty()
+                        )
+                {
+                        read_buffer.erase(0, 1);
+                }
 #endif
-		return read_buffer;
-	}
+                return read_buffer;
+        }
 
 	void hwHid::discardStaleReports() noexcept
 	{
@@ -514,12 +660,14 @@ NAMESPACE_SOUP
 #if SOUP_WINDOWS
 		CancelIoEx(handle, &read_overlapped);
 #elif SOUP_LINUX
-		if (reading)
-		{
-			pthread_kill(read_thrd, SIGUSR1);
-		}
+                if (reading)
+                {
+                        pthread_kill(read_thrd, SIGUSR1);
+                }
+#elif SOUP_MACOS
+                // nothing
 #endif
-	}
+        }
 
 	// SET_REPORT response
 	void hwHid::receiveFeatureReport(Buffer<>& buf) const
@@ -532,9 +680,17 @@ NAMESPACE_SOUP
 
 		SOUP_ASSERT(HidD_GetFeature(handle, buf.data(), static_cast<ULONG>(buf.size())));
 #elif SOUP_LINUX
-		// TODO
+                // TODO
+#elif SOUP_MACOS
+                if (buf.size() < feature_report_byte_length)
+                {
+                        buf.insert_back(feature_report_byte_length - buf.size(), '\0');
+                }
+                CFIndex len = buf.size();
+                IOHIDDeviceGetReport((IOHIDDeviceRef)device, kIOHIDReportTypeFeature, buf.empty()?0:static_cast<uint8_t>(buf.at(0)), (uint8_t*)buf.data(), &len);
+                buf.resize(len);
 #endif
-	}
+        }
 
 	bool hwHid::sendReport(Buffer<>&& buf) const noexcept
 	{
@@ -564,11 +720,15 @@ NAMESPACE_SOUP
 		}
 		return result && bytesWritten == size;
 #elif SOUP_LINUX
-		return write(handle, data, size) == size;
+                return write(handle, data, size) == size;
+#elif SOUP_MACOS
+                const uint8_t* bytes = static_cast<const uint8_t*>(data);
+                uint8_t report_id = size > 0 ? bytes[0] : 0;
+                return IOHIDDeviceSetReport((IOHIDDeviceRef)device, kIOHIDReportTypeOutput, report_id, bytes, size) == kIOReturnSuccess;
 #else
-		return false;
+                return false;
 #endif
-	}
+        }
 
 	// SET_REPORT request - bmRequestType = 0x21, bRequest = SET_REPORT (0x09), wValue = 0x0300 (ReportId = 0, ReportType = Feature (3))
 	bool hwHid::sendFeatureReport(Buffer<>&& buf) const noexcept
@@ -582,11 +742,13 @@ NAMESPACE_SOUP
 
 		return HidD_SetFeature(handle, buf.data(), static_cast<ULONG>(buf.size()));
 #elif SOUP_LINUX
-		return ioctl(handle, HIDIOCSFEATURE(buf.size()), buf.data()) == buf.size();
+                return ioctl(handle, HIDIOCSFEATURE(buf.size()), buf.data()) == buf.size();
+#elif SOUP_MACOS
+                return IOHIDDeviceSetReport((IOHIDDeviceRef)device, kIOHIDReportTypeFeature, buf.empty()?0:static_cast<uint8_t>(buf.at(0)), (uint8_t*)buf.data(), buf.size()) == kIOReturnSuccess;
 #else
-		return false;
+                return false;
 #endif
-	}
+        }
 
 #if SOUP_WINDOWS
 	void hwHid::kickOffRead() noexcept
@@ -804,10 +966,18 @@ NAMESPACE_SOUP
 
 		return result;
 #elif SOUP_LINUX
-		const auto rawdesc = string::fromFile(this->path + "/device/report_descriptor");
-		return HidReportDescriptor::parse(rawdesc.data(), rawdesc.size());
+                const auto rawdesc = string::fromFile(this->path + "/device/report_descriptor");
+                return HidReportDescriptor::parse(rawdesc.data(), rawdesc.size());
+#elif SOUP_MACOS
+                if (CFDataRef desc = (CFDataRef)IOHIDDeviceGetProperty((IOHIDDeviceRef)device, CFSTR(kIOHIDReportDescriptorKey)))
+                {
+                        const UInt8* data = CFDataGetBytePtr(desc);
+                        CFIndex len = CFDataGetLength(desc);
+                        return HidReportDescriptor::parse((const char*)data, len);
+                }
+                return {};
 #else
-		return {};
+                return {};
 #endif
-	}
+        }
 }

--- a/soup/hwHid.cpp
+++ b/soup/hwHid.cpp
@@ -322,62 +322,119 @@ NAMESPACE_SOUP
                                         }
 
                                         int32_t vid = 0, pid = 0, usage_page = 0, usage = 0;
-                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDVendorIDKey)), kCFNumberSInt32Type, &vid);
-                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDProductIDKey)), kCFNumberSInt32Type, &pid);
-                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDPrimaryUsagePageKey)), kCFNumberSInt32Type, &usage_page);
-                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDPrimaryUsageKey)), kCFNumberSInt32Type, &usage);
+                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDVendorIDKey)))
+                                        {
+                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
+                                                {
+                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &vid);
+                                                }
+                                        }
+                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDProductIDKey)))
+                                        {
+                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
+                                                {
+                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &pid);
+                                                }
+                                        }
+                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDPrimaryUsagePageKey)))
+                                        {
+                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
+                                                {
+                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &usage_page);
+                                                }
+                                        }
+                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDPrimaryUsageKey)))
+                                        {
+                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
+                                                {
+                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &usage);
+                                                }
+                                        }
                                         hid.vendor_id = static_cast<uint16_t>(vid);
                                         hid.product_id = static_cast<uint16_t>(pid);
                                         hid.usage_page = static_cast<uint16_t>(usage_page);
                                         hid.usage = static_cast<uint16_t>(usage);
 
                                         int32_t in_sz = 0, out_sz = 0, feat_sz = 0;
-                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxInputReportSizeKey)), kCFNumberSInt32Type, &in_sz);
-                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxOutputReportSizeKey)), kCFNumberSInt32Type, &out_sz);
-                                        CFNumberGetValue((CFNumberRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxFeatureReportSizeKey)), kCFNumberSInt32Type, &feat_sz);
+                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxInputReportSizeKey)))
+                                        {
+                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
+                                                {
+                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &in_sz);
+                                                }
+                                        }
+                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxOutputReportSizeKey)))
+                                        {
+                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
+                                                {
+                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &out_sz);
+                                                }
+                                        }
+                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxFeatureReportSizeKey)))
+                                        {
+                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
+                                                {
+                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &feat_sz);
+                                                }
+                                        }
                                         hid.input_report_byte_length = static_cast<uint16_t>(in_sz);
                                         hid.output_report_byte_length = static_cast<uint16_t>(out_sz);
                                         hid.feature_report_byte_length = static_cast<uint16_t>(feat_sz);
 
-                                        if (CFStringRef transport = (CFStringRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDTransportKey)))
+                                        if (CFTypeRef transport = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDTransportKey)))
                                         {
-                                                hid.is_bluetooth = (CFStringCompare(transport, CFSTR("Bluetooth"), 0) == kCFCompareEqualTo);
-                                        }
-
-                                        if (CFStringRef manu = (CFStringRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDManufacturerKey)))
-                                        {
-                                                char buf[256];
-                                                if (CFStringGetCString(manu, buf, sizeof(buf), kCFStringEncodingUTF8))
+                                                if (CFGetTypeID(transport) == CFStringGetTypeID())
                                                 {
-                                                        hid.manufacturer_name = buf;
-                                                }
-                                        }
-                                        if (CFStringRef prod = (CFStringRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDProductKey)))
-                                        {
-                                                char buf[256];
-                                                if (CFStringGetCString(prod, buf, sizeof(buf), kCFStringEncodingUTF8))
-                                                {
-                                                        hid.product_name = buf;
-                                                }
-                                        }
-                                        if (CFStringRef serial = (CFStringRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDSerialNumberKey)))
-                                        {
-                                                char buf[256];
-                                                if (CFStringGetCString(serial, buf, sizeof(buf), kCFStringEncodingUTF8))
-                                                {
-                                                        hid.serial_number = buf;
+                                                        hid.is_bluetooth = (CFStringCompare((CFStringRef)transport, CFSTR("Bluetooth"), 0) == kCFCompareEqualTo);
                                                 }
                                         }
 
-                                        if (CFDataRef desc = (CFDataRef)IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDReportDescriptorKey)))
+                                        if (CFTypeRef manu = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDManufacturerKey)))
                                         {
-                                                const UInt8* data = CFDataGetBytePtr(desc);
-                                                CFIndex len = CFDataGetLength(desc);
-                                                auto rd = HidReportDescriptor::parse((const char*)data, len);
-                                                hid.report_ids = std::move(rd.report_ids);
-                                                if (!in_sz) hid.input_report_byte_length = rd.input_report_byte_length;
-                                                if (!out_sz) hid.output_report_byte_length = rd.output_report_byte_length;
-                                                if (!feat_sz) hid.feature_report_byte_length = rd.feature_report_byte_length;
+                                                if (CFGetTypeID(manu) == CFStringGetTypeID())
+                                                {
+                                                        char buf[256];
+                                                        if (CFStringGetCString((CFStringRef)manu, buf, sizeof(buf), kCFStringEncodingUTF8))
+                                                        {
+                                                                hid.manufacturer_name = buf;
+                                                        }
+                                                }
+                                        }
+                                        if (CFTypeRef prod = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDProductKey)))
+                                        {
+                                                if (CFGetTypeID(prod) == CFStringGetTypeID())
+                                                {
+                                                        char buf[256];
+                                                        if (CFStringGetCString((CFStringRef)prod, buf, sizeof(buf), kCFStringEncodingUTF8))
+                                                        {
+                                                                hid.product_name = buf;
+                                                        }
+                                                }
+                                        }
+                                        if (CFTypeRef serial = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDSerialNumberKey)))
+                                        {
+                                                if (CFGetTypeID(serial) == CFStringGetTypeID())
+                                                {
+                                                        char buf[256];
+                                                        if (CFStringGetCString((CFStringRef)serial, buf, sizeof(buf), kCFStringEncodingUTF8))
+                                                        {
+                                                                hid.serial_number = buf;
+                                                        }
+                                                }
+                                        }
+
+                                        if (CFTypeRef desc = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDReportDescriptorKey)))
+                                        {
+                                                if (CFGetTypeID(desc) == CFDataGetTypeID())
+                                                {
+                                                        const UInt8* data = CFDataGetBytePtr((CFDataRef)desc);
+                                                        CFIndex len = CFDataGetLength((CFDataRef)desc);
+                                                        auto rd = HidReportDescriptor::parse((const char*)data, len);
+                                                        hid.report_ids = std::move(rd.report_ids);
+                                                        if (!in_sz) hid.input_report_byte_length = rd.input_report_byte_length;
+                                                        if (!out_sz) hid.output_report_byte_length = rd.output_report_byte_length;
+                                                        if (!feat_sz) hid.feature_report_byte_length = rd.feature_report_byte_length;
+                                                }
                                         }
 
                                         if (IOHIDDeviceOpen(dev, kIOHIDOptionsTypeNone) == kIOReturnSuccess)
@@ -503,7 +560,7 @@ NAMESPACE_SOUP
                 pfd.revents = 0;
                 return poll(&pfd, 1, 0) != 0;
 #elif SOUP_MACOS
-                return true;
+                return device != nullptr;
 #else
                 return true;
 #endif
@@ -540,6 +597,11 @@ NAMESPACE_SOUP
                 reading = false;
                 read_buffer.resize(bytes_read < 0 ? 0 : bytes_read);
 #elif SOUP_MACOS
+                if (!device)
+                {
+                        read_buffer.clear();
+                        return read_buffer;
+                }
                 CFIndex len = input_report_byte_length;
                 if (len == 0)
                 {
@@ -565,14 +627,14 @@ NAMESPACE_SOUP
 		}
 #elif SOUP_LINUX
                 SOUP_UNUSED(receiveReport());
-                if (!report_ids.empty())
+                if (!report_ids.empty() && !read_buffer.empty())
                 {
                         out_report_id = read_buffer.at(0);
                         read_buffer.erase(0, 1);
                 }
 #elif SOUP_MACOS
                 SOUP_UNUSED(receiveReport());
-                if (!report_ids.empty())
+                if (!report_ids.empty() && !read_buffer.empty())
                 {
                         out_report_id = read_buffer.at(0);
                         read_buffer.erase(0, 1);
@@ -637,6 +699,7 @@ NAMESPACE_SOUP
                 SOUP_UNUSED(receiveReport());
                 if (input_report_byte_length != 0
                         && !report_ids.empty()
+                        && !read_buffer.empty()
                         )
                 {
                         read_buffer.erase(0, 1);
@@ -682,6 +745,11 @@ NAMESPACE_SOUP
 #elif SOUP_LINUX
                 // TODO
 #elif SOUP_MACOS
+                if (!device)
+                {
+                        buf.clear();
+                        return;
+                }
                 if (buf.size() < feature_report_byte_length)
                 {
                         buf.insert_back(feature_report_byte_length - buf.size(), '\0');
@@ -722,6 +790,10 @@ NAMESPACE_SOUP
 #elif SOUP_LINUX
                 return write(handle, data, size) == size;
 #elif SOUP_MACOS
+                if (!device)
+                {
+                        return false;
+                }
                 const uint8_t* bytes = static_cast<const uint8_t*>(data);
                 uint8_t report_id = size > 0 ? bytes[0] : 0;
                 return IOHIDDeviceSetReport((IOHIDDeviceRef)device, kIOHIDReportTypeOutput, report_id, bytes, size) == kIOReturnSuccess;
@@ -744,6 +816,10 @@ NAMESPACE_SOUP
 #elif SOUP_LINUX
                 return ioctl(handle, HIDIOCSFEATURE(buf.size()), buf.data()) == buf.size();
 #elif SOUP_MACOS
+                if (!device)
+                {
+                        return false;
+                }
                 return IOHIDDeviceSetReport((IOHIDDeviceRef)device, kIOHIDReportTypeFeature, buf.empty()?0:static_cast<uint8_t>(buf.at(0)), (uint8_t*)buf.data(), buf.size()) == kIOReturnSuccess;
 #else
                 return false;
@@ -969,11 +1045,18 @@ NAMESPACE_SOUP
                 const auto rawdesc = string::fromFile(this->path + "/device/report_descriptor");
                 return HidReportDescriptor::parse(rawdesc.data(), rawdesc.size());
 #elif SOUP_MACOS
-                if (CFDataRef desc = (CFDataRef)IOHIDDeviceGetProperty((IOHIDDeviceRef)device, CFSTR(kIOHIDReportDescriptorKey)))
+                if (!device)
                 {
-                        const UInt8* data = CFDataGetBytePtr(desc);
-                        CFIndex len = CFDataGetLength(desc);
-                        return HidReportDescriptor::parse((const char*)data, len);
+                        return {};
+                }
+                if (CFTypeRef desc = IOHIDDeviceGetProperty((IOHIDDeviceRef)device, CFSTR(kIOHIDReportDescriptorKey)))
+                {
+                        if (CFGetTypeID(desc) == CFDataGetTypeID())
+                        {
+                                const UInt8* data = CFDataGetBytePtr((CFDataRef)desc);
+                                CFIndex len = CFDataGetLength((CFDataRef)desc);
+                                return HidReportDescriptor::parse((const char*)data, len);
+                        }
                 }
                 return {};
 #else

--- a/soup/hwHid.cpp
+++ b/soup/hwHid.cpp
@@ -239,11 +239,11 @@ NAMESPACE_SOUP
 		use_udev_func(udev_device_get_parent_with_subsystem_devtype);
 		use_udev_func(udev_device_get_sysattr_value);
 
-                if (udev* udev = udev_new())
-                {
-                        udev_enumerate* enumerate = udev_enumerate_new(udev);
-                        udev_enumerate_add_match_subsystem(enumerate, "hidraw");
-                        udev_enumerate_scan_devices(enumerate);
+		if (udev* udev = udev_new())
+		{
+			udev_enumerate* enumerate = udev_enumerate_new(udev);
+			udev_enumerate_add_match_subsystem(enumerate, "hidraw");
+			udev_enumerate_scan_devices(enumerate);
 
 			udev_list_entry* devices;
 			devices = udev_enumerate_get_list_entry(enumerate);
@@ -292,168 +292,168 @@ NAMESPACE_SOUP
 				}
 			}
 
-                        udev_enumerate_unref(enumerate);
-                        udev_unref(udev);
-                }
+			udev_enumerate_unref(enumerate);
+			udev_unref(udev);
+		}
 #elif SOUP_MACOS
-                IOHIDManagerRef manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
-                if (manager)
-                {
-                        IOHIDManagerSetDeviceMatching(manager, NULL);
-                        IOHIDManagerOpen(manager, kIOHIDOptionsTypeNone);
-                        CFSetRef device_set = IOHIDManagerCopyDevices(manager);
-                        if (device_set)
-                        {
-                                CFIndex num = CFSetGetCount(device_set);
-                                std::vector<IOHIDDeviceRef> devices(num);
-                                CFSetGetValues(device_set, (const void**)devices.data());
-                                for (CFIndex i = 0; i < num; ++i)
-                                {
-                                        IOHIDDeviceRef dev = devices[i];
-                                        hwHid hid{};
+		IOHIDManagerRef manager = IOHIDManagerCreate(kCFAllocatorDefault, kIOHIDOptionsTypeNone);
+		if (manager)
+		{
+			IOHIDManagerSetDeviceMatching(manager, NULL);
+			IOHIDManagerOpen(manager, kIOHIDOptionsTypeNone);
+			CFSetRef device_set = IOHIDManagerCopyDevices(manager);
+			if (device_set)
+			{
+				CFIndex num = CFSetGetCount(device_set);
+				std::vector<IOHIDDeviceRef> devices(num);
+				CFSetGetValues(device_set, (const void**)devices.data());
+				for (CFIndex i = 0; i < num; ++i)
+				{
+					IOHIDDeviceRef dev = devices[i];
+					hwHid hid{};
 
-                                        if (io_registry_entry_t entry = IOHIDDeviceGetService(dev))
-                                        {
-                                                io_string_t path;
-                                                if (IORegistryEntryGetPath(entry, kIOServicePlane, path) == KERN_SUCCESS)
-                                                {
-                                                        hid.path = path;
-                                                }
-                                        }
+					if (io_registry_entry_t entry = IOHIDDeviceGetService(dev))
+					{
+						io_string_t path;
+						if (IORegistryEntryGetPath(entry, kIOServicePlane, path) == KERN_SUCCESS)
+						{
+							hid.path = path;
+						}
+					}
 
-                                        int32_t vid = 0, pid = 0, usage_page = 0, usage = 0;
-                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDVendorIDKey)))
-                                        {
-                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
-                                                {
-                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &vid);
-                                                }
-                                        }
-                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDProductIDKey)))
-                                        {
-                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
-                                                {
-                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &pid);
-                                                }
-                                        }
-                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDPrimaryUsagePageKey)))
-                                        {
-                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
-                                                {
-                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &usage_page);
-                                                }
-                                        }
-                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDPrimaryUsageKey)))
-                                        {
-                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
-                                                {
-                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &usage);
-                                                }
-                                        }
-                                        hid.vendor_id = static_cast<uint16_t>(vid);
-                                        hid.product_id = static_cast<uint16_t>(pid);
-                                        hid.usage_page = static_cast<uint16_t>(usage_page);
-                                        hid.usage = static_cast<uint16_t>(usage);
+					int32_t vid = 0, pid = 0, usage_page = 0, usage = 0;
+					if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDVendorIDKey)))
+					{
+						if (CFGetTypeID(ref) == CFNumberGetTypeID())
+						{
+							CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &vid);
+						}
+					}
+					if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDProductIDKey)))
+					{
+						if (CFGetTypeID(ref) == CFNumberGetTypeID())
+						{
+							CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &pid);
+						}
+					}
+					if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDPrimaryUsagePageKey)))
+					{
+						if (CFGetTypeID(ref) == CFNumberGetTypeID())
+						{
+							CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &usage_page);
+						}
+					}
+					if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDPrimaryUsageKey)))
+					{
+						if (CFGetTypeID(ref) == CFNumberGetTypeID())
+						{
+							CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &usage);
+						}
+					}
+					hid.vendor_id = static_cast<uint16_t>(vid);
+					hid.product_id = static_cast<uint16_t>(pid);
+					hid.usage_page = static_cast<uint16_t>(usage_page);
+					hid.usage = static_cast<uint16_t>(usage);
 
-                                        int32_t in_sz = 0, out_sz = 0, feat_sz = 0;
-                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxInputReportSizeKey)))
-                                        {
-                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
-                                                {
-                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &in_sz);
-                                                }
-                                        }
-                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxOutputReportSizeKey)))
-                                        {
-                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
-                                                {
-                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &out_sz);
-                                                }
-                                        }
-                                        if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxFeatureReportSizeKey)))
-                                        {
-                                                if (CFGetTypeID(ref) == CFNumberGetTypeID())
-                                                {
-                                                        CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &feat_sz);
-                                                }
-                                        }
-                                        hid.input_report_byte_length = static_cast<uint16_t>(in_sz);
-                                        hid.output_report_byte_length = static_cast<uint16_t>(out_sz);
-                                        hid.feature_report_byte_length = static_cast<uint16_t>(feat_sz);
+					int32_t in_sz = 0, out_sz = 0, feat_sz = 0;
+					if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxInputReportSizeKey)))
+					{
+						if (CFGetTypeID(ref) == CFNumberGetTypeID())
+						{
+							CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &in_sz);
+						}
+					}
+					if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxOutputReportSizeKey)))
+					{
+						if (CFGetTypeID(ref) == CFNumberGetTypeID())
+						{
+							CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &out_sz);
+						}
+					}
+					if (CFTypeRef ref = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDMaxFeatureReportSizeKey)))
+					{
+						if (CFGetTypeID(ref) == CFNumberGetTypeID())
+						{
+							CFNumberGetValue((CFNumberRef)ref, kCFNumberSInt32Type, &feat_sz);
+						}
+					}
+					hid.input_report_byte_length = static_cast<uint16_t>(in_sz);
+					hid.output_report_byte_length = static_cast<uint16_t>(out_sz);
+					hid.feature_report_byte_length = static_cast<uint16_t>(feat_sz);
 
-                                        if (CFTypeRef transport = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDTransportKey)))
-                                        {
-                                                if (CFGetTypeID(transport) == CFStringGetTypeID())
-                                                {
-                                                        hid.is_bluetooth = (CFStringCompare((CFStringRef)transport, CFSTR("Bluetooth"), 0) == kCFCompareEqualTo);
-                                                }
-                                        }
+					if (CFTypeRef transport = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDTransportKey)))
+					{
+						if (CFGetTypeID(transport) == CFStringGetTypeID())
+						{
+							hid.is_bluetooth = (CFStringCompare((CFStringRef)transport, CFSTR("Bluetooth"), 0) == kCFCompareEqualTo);
+						}
+					}
 
-                                        if (CFTypeRef manu = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDManufacturerKey)))
-                                        {
-                                                if (CFGetTypeID(manu) == CFStringGetTypeID())
-                                                {
-                                                        char buf[256];
-                                                        if (CFStringGetCString((CFStringRef)manu, buf, sizeof(buf), kCFStringEncodingUTF8))
-                                                        {
-                                                                hid.manufacturer_name = buf;
-                                                        }
-                                                }
-                                        }
-                                        if (CFTypeRef prod = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDProductKey)))
-                                        {
-                                                if (CFGetTypeID(prod) == CFStringGetTypeID())
-                                                {
-                                                        char buf[256];
-                                                        if (CFStringGetCString((CFStringRef)prod, buf, sizeof(buf), kCFStringEncodingUTF8))
-                                                        {
-                                                                hid.product_name = buf;
-                                                        }
-                                                }
-                                        }
-                                        if (CFTypeRef serial = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDSerialNumberKey)))
-                                        {
-                                                if (CFGetTypeID(serial) == CFStringGetTypeID())
-                                                {
-                                                        char buf[256];
-                                                        if (CFStringGetCString((CFStringRef)serial, buf, sizeof(buf), kCFStringEncodingUTF8))
-                                                        {
-                                                                hid.serial_number = buf;
-                                                        }
-                                                }
-                                        }
+					if (CFTypeRef manu = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDManufacturerKey)))
+					{
+						if (CFGetTypeID(manu) == CFStringGetTypeID())
+						{
+							char buf[256];
+							if (CFStringGetCString((CFStringRef)manu, buf, sizeof(buf), kCFStringEncodingUTF8))
+							{
+								hid.manufacturer_name = buf;
+							}
+						}
+					}
+					if (CFTypeRef prod = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDProductKey)))
+					{
+						if (CFGetTypeID(prod) == CFStringGetTypeID())
+						{
+							char buf[256];
+							if (CFStringGetCString((CFStringRef)prod, buf, sizeof(buf), kCFStringEncodingUTF8))
+							{
+								hid.product_name = buf;
+							}
+						}
+					}
+					if (CFTypeRef serial = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDSerialNumberKey)))
+					{
+						if (CFGetTypeID(serial) == CFStringGetTypeID())
+						{
+							char buf[256];
+							if (CFStringGetCString((CFStringRef)serial, buf, sizeof(buf), kCFStringEncodingUTF8))
+							{
+								hid.serial_number = buf;
+							}
+						}
+					}
 
-                                        if (CFTypeRef desc = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDReportDescriptorKey)))
-                                        {
-                                                if (CFGetTypeID(desc) == CFDataGetTypeID())
-                                                {
-                                                        const UInt8* data = CFDataGetBytePtr((CFDataRef)desc);
-                                                        CFIndex len = CFDataGetLength((CFDataRef)desc);
-                                                        auto rd = HidReportDescriptor::parse((const char*)data, len);
-                                                        hid.report_ids = std::move(rd.report_ids);
-                                                        if (!in_sz) hid.input_report_byte_length = rd.input_report_byte_length;
-                                                        if (!out_sz) hid.output_report_byte_length = rd.output_report_byte_length;
-                                                        if (!feat_sz) hid.feature_report_byte_length = rd.feature_report_byte_length;
-                                                }
-                                        }
+					if (CFTypeRef desc = IOHIDDeviceGetProperty(dev, CFSTR(kIOHIDReportDescriptorKey)))
+					{
+						if (CFGetTypeID(desc) == CFDataGetTypeID())
+						{
+							const UInt8* data = CFDataGetBytePtr((CFDataRef)desc);
+							CFIndex len = CFDataGetLength((CFDataRef)desc);
+							auto rd = HidReportDescriptor::parse((const char*)data, len);
+							hid.report_ids = std::move(rd.report_ids);
+							if (!in_sz) hid.input_report_byte_length = rd.input_report_byte_length;
+							if (!out_sz) hid.output_report_byte_length = rd.output_report_byte_length;
+							if (!feat_sz) hid.feature_report_byte_length = rd.feature_report_byte_length;
+						}
+					}
 
-                                        if (IOHIDDeviceOpen(dev, kIOHIDOptionsTypeNone) == kIOReturnSuccess)
-                                        {
-                                                CFRetain(dev);
-                                                hid.device = dev;
-                                        }
+					if (IOHIDDeviceOpen(dev, kIOHIDOptionsTypeNone) == kIOReturnSuccess)
+					{
+						CFRetain(dev);
+						hid.device = dev;
+					}
 
-                                        hid.read_buffer.reserve(hid.input_report_byte_length < 1024 ? 1024 : hid.input_report_byte_length);
-                                        res.emplace_back(std::move(hid));
-                                }
-                                CFRelease(device_set);
-                        }
-                        IOHIDManagerClose(manager, kIOHIDOptionsTypeNone);
-                        CFRelease(manager);
-                }
+					hid.read_buffer.reserve(hid.input_report_byte_length < 1024 ? 1024 : hid.input_report_byte_length);
+					res.emplace_back(std::move(hid));
+				}
+				CFRelease(device_set);
+			}
+			IOHIDManagerClose(manager, kIOHIDOptionsTypeNone);
+			CFRelease(manager);
+		}
 #endif
-                return res;
-        }
+		return res;
+	}
 
 #if SOUP_WINDOWS
 	std::string hwHid::getManufacturerName() const
@@ -521,26 +521,26 @@ NAMESPACE_SOUP
 			HidD_FreePreparsedData(pp_data);
 		}
 #elif SOUP_LINUX
-                if (report_id == 0)
-                {
-                        ret = report_ids.empty();
-                }
-                else
-                {
-                        ret = report_ids.count(report_id) != 0;
-                }
+		if (report_id == 0)
+		{
+			ret = report_ids.empty();
+		}
+		else
+		{
+			ret = report_ids.count(report_id) != 0;
+		}
 #elif SOUP_MACOS
-                if (report_id == 0)
-                {
-                        ret = report_ids.empty();
-                }
-                else
-                {
-                        ret = report_ids.count(report_id) != 0;
-                }
+		if (report_id == 0)
+		{
+			ret = report_ids.empty();
+		}
+		else
+		{
+			ret = report_ids.count(report_id) != 0;
+		}
 #endif
-                return ret;
-        }
+		return ret;
+	}
 
 	bool hwHid::hasReport() noexcept
 	{
@@ -554,17 +554,17 @@ NAMESPACE_SOUP
 			|| disconnected
 			;
 #elif SOUP_LINUX
-                pollfd pfd;
-                pfd.fd = handle;
-                pfd.events = POLLIN;
-                pfd.revents = 0;
-                return poll(&pfd, 1, 0) != 0;
+		pollfd pfd;
+		pfd.fd = handle;
+		pfd.events = POLLIN;
+		pfd.revents = 0;
+		return poll(&pfd, 1, 0) != 0;
 #elif SOUP_MACOS
-                return device != nullptr;
+		return device != nullptr;
 #else
-                return true;
+		return true;
 #endif
-        }
+	}
 
 #if SOUP_LINUX
 	static bool setup_sig_handler = false;
@@ -583,37 +583,37 @@ NAMESPACE_SOUP
 			read_buffer.erase(0, 1);
 		}
 #elif SOUP_LINUX
-                if (!setup_sig_handler)
-                {
-                        signal::handle(SIGUSR1, [](int)
-                        {
-                                killed_via_signal = true;
-                        });
-                }
-                killed_via_signal = false;
-                read_thrd = pthread_self();
-                reading = true;
-                int bytes_read = ::read(handle, read_buffer.data(), read_buffer.capacity());
-                reading = false;
-                read_buffer.resize(bytes_read < 0 ? 0 : bytes_read);
+		if (!setup_sig_handler)
+		{
+			signal::handle(SIGUSR1, [](int)
+			{
+				killed_via_signal = true;
+			});
+		}
+		killed_via_signal = false;
+		read_thrd = pthread_self();
+		reading = true;
+		int bytes_read = ::read(handle, read_buffer.data(), read_buffer.capacity());
+		reading = false;
+		read_buffer.resize(bytes_read < 0 ? 0 : bytes_read);
 #elif SOUP_MACOS
-                if (!device)
-                {
-                        read_buffer.clear();
-                        return read_buffer;
-                }
-                CFIndex len = input_report_byte_length;
-                if (len == 0)
-                {
-                        len = 64;
-                }
-                read_buffer.resize(len);
-                IOHIDDeviceRef dev = (IOHIDDeviceRef)device;
-                IOReturn r = IOHIDDeviceGetReport(dev, kIOHIDReportTypeInput, 0, (uint8_t*)read_buffer.data(), &len);
-                read_buffer.resize(r == kIOReturnSuccess ? len : 0);
+		if (!device)
+		{
+			read_buffer.clear();
+			return read_buffer;
+		}
+		CFIndex len = input_report_byte_length;
+		if (len == 0)
+		{
+			len = 64;
+		}
+		read_buffer.resize(len);
+		IOHIDDeviceRef dev = (IOHIDDeviceRef)device;
+		IOReturn r = IOHIDDeviceGetReport(dev, kIOHIDReportTypeInput, 0, (uint8_t*)read_buffer.data(), &len);
+		read_buffer.resize(r == kIOReturnSuccess ? len : 0);
 #endif
-                return read_buffer;
-        }
+		return read_buffer;
+	}
 
 	const Buffer<>& hwHid::receiveReport(uint8_t& out_report_id) noexcept
 	{
@@ -626,22 +626,22 @@ NAMESPACE_SOUP
 			read_buffer.erase(0, 1);
 		}
 #elif SOUP_LINUX
-                SOUP_UNUSED(receiveReport());
-                if (!report_ids.empty() && !read_buffer.empty())
-                {
-                        out_report_id = read_buffer.at(0);
-                        read_buffer.erase(0, 1);
-                }
+		SOUP_UNUSED(receiveReport());
+		if (!report_ids.empty() && !read_buffer.empty())
+		{
+			out_report_id = read_buffer.at(0);
+			read_buffer.erase(0, 1);
+		}
 #elif SOUP_MACOS
-                SOUP_UNUSED(receiveReport());
-                if (!report_ids.empty() && !read_buffer.empty())
-                {
-                        out_report_id = read_buffer.at(0);
-                        read_buffer.erase(0, 1);
-                }
+		SOUP_UNUSED(receiveReport());
+		if (!report_ids.empty() && !read_buffer.empty())
+		{
+			out_report_id = read_buffer.at(0);
+			read_buffer.erase(0, 1);
+		}
 #endif
-                return read_buffer;
-        }
+		return read_buffer;
+	}
 
 	// URB_INTERRUPT in
 	const Buffer<>& hwHid::receiveReportWithReportId() noexcept
@@ -663,20 +663,20 @@ NAMESPACE_SOUP
 		}
 		read_buffer.resize(bytes_read);
 #elif SOUP_LINUX
-                SOUP_UNUSED(receiveReport());
-                if (report_ids.empty())
-                {
-                        read_buffer.insert_front(1, 0);
-                }
+		SOUP_UNUSED(receiveReport());
+		if (report_ids.empty())
+		{
+			read_buffer.insert_front(1, 0);
+		}
 #elif SOUP_MACOS
-                SOUP_UNUSED(receiveReport());
-                if (report_ids.empty())
-                {
-                        read_buffer.insert_front(1, 0);
-                }
+		SOUP_UNUSED(receiveReport());
+		if (report_ids.empty())
+		{
+			read_buffer.insert_front(1, 0);
+		}
 #endif
-                return read_buffer;
-        }
+		return read_buffer;
+	}
 
 	// URB_INTERRUPT in
 	const Buffer<>& hwHid::receiveReportWithoutReportId() noexcept
@@ -688,25 +688,25 @@ NAMESPACE_SOUP
 			read_buffer.erase(0, 1);
 		}
 #elif SOUP_LINUX
-                SOUP_UNUSED(receiveReport());
-                if (input_report_byte_length != 0
-                        && !report_ids.empty()
-                        )
-                {
-                        read_buffer.erase(0, 1);
-                }
+		SOUP_UNUSED(receiveReport());
+		if (input_report_byte_length != 0
+			&& !report_ids.empty()
+			)
+		{
+			read_buffer.erase(0, 1);
+		}
 #elif SOUP_MACOS
-                SOUP_UNUSED(receiveReport());
-                if (input_report_byte_length != 0
-                        && !report_ids.empty()
-                        && !read_buffer.empty()
-                        )
-                {
-                        read_buffer.erase(0, 1);
-                }
+		SOUP_UNUSED(receiveReport());
+		if (input_report_byte_length != 0
+			&& !report_ids.empty()
+			&& !read_buffer.empty()
+			)
+		{
+			read_buffer.erase(0, 1);
+		}
 #endif
-                return read_buffer;
-        }
+		return read_buffer;
+	}
 
 	void hwHid::discardStaleReports() noexcept
 	{
@@ -723,14 +723,14 @@ NAMESPACE_SOUP
 #if SOUP_WINDOWS
 		CancelIoEx(handle, &read_overlapped);
 #elif SOUP_LINUX
-                if (reading)
-                {
-                        pthread_kill(read_thrd, SIGUSR1);
-                }
+		if (reading)
+		{
+			pthread_kill(read_thrd, SIGUSR1);
+		}
 #elif SOUP_MACOS
-                // nothing
+		// nothing
 #endif
-        }
+	}
 
 	// SET_REPORT response
 	void hwHid::receiveFeatureReport(Buffer<>& buf) const
@@ -743,22 +743,22 @@ NAMESPACE_SOUP
 
 		SOUP_ASSERT(HidD_GetFeature(handle, buf.data(), static_cast<ULONG>(buf.size())));
 #elif SOUP_LINUX
-                // TODO
+		// TODO
 #elif SOUP_MACOS
-                if (!device)
-                {
-                        buf.clear();
-                        return;
-                }
-                if (buf.size() < feature_report_byte_length)
-                {
-                        buf.insert_back(feature_report_byte_length - buf.size(), '\0');
-                }
-                CFIndex len = buf.size();
-                IOHIDDeviceGetReport((IOHIDDeviceRef)device, kIOHIDReportTypeFeature, buf.empty()?0:static_cast<uint8_t>(buf.at(0)), (uint8_t*)buf.data(), &len);
-                buf.resize(len);
+		if (!device)
+		{
+			buf.clear();
+			return;
+		}
+		if (buf.size() < feature_report_byte_length)
+		{
+			buf.insert_back(feature_report_byte_length - buf.size(), '\0');
+		}
+		CFIndex len = buf.size();
+		IOHIDDeviceGetReport((IOHIDDeviceRef)device, kIOHIDReportTypeFeature, buf.empty()?0:static_cast<uint8_t>(buf.at(0)), (uint8_t*)buf.data(), &len);
+		buf.resize(len);
 #endif
-        }
+	}
 
 	bool hwHid::sendReport(Buffer<>&& buf) const noexcept
 	{
@@ -788,19 +788,19 @@ NAMESPACE_SOUP
 		}
 		return result && bytesWritten == size;
 #elif SOUP_LINUX
-                return write(handle, data, size) == size;
+		return write(handle, data, size) == size;
 #elif SOUP_MACOS
-                if (!device)
-                {
-                        return false;
-                }
-                const uint8_t* bytes = static_cast<const uint8_t*>(data);
-                uint8_t report_id = size > 0 ? bytes[0] : 0;
-                return IOHIDDeviceSetReport((IOHIDDeviceRef)device, kIOHIDReportTypeOutput, report_id, bytes, size) == kIOReturnSuccess;
+		if (!device)
+		{
+			return false;
+		}
+		const uint8_t* bytes = static_cast<const uint8_t*>(data);
+		uint8_t report_id = size > 0 ? bytes[0] : 0;
+		return IOHIDDeviceSetReport((IOHIDDeviceRef)device, kIOHIDReportTypeOutput, report_id, bytes, size) == kIOReturnSuccess;
 #else
-                return false;
+		return false;
 #endif
-        }
+	}
 
 	// SET_REPORT request - bmRequestType = 0x21, bRequest = SET_REPORT (0x09), wValue = 0x0300 (ReportId = 0, ReportType = Feature (3))
 	bool hwHid::sendFeatureReport(Buffer<>&& buf) const noexcept
@@ -814,17 +814,17 @@ NAMESPACE_SOUP
 
 		return HidD_SetFeature(handle, buf.data(), static_cast<ULONG>(buf.size()));
 #elif SOUP_LINUX
-                return ioctl(handle, HIDIOCSFEATURE(buf.size()), buf.data()) == buf.size();
+		return ioctl(handle, HIDIOCSFEATURE(buf.size()), buf.data()) == buf.size();
 #elif SOUP_MACOS
-                if (!device)
-                {
-                        return false;
-                }
-                return IOHIDDeviceSetReport((IOHIDDeviceRef)device, kIOHIDReportTypeFeature, buf.empty()?0:static_cast<uint8_t>(buf.at(0)), (uint8_t*)buf.data(), buf.size()) == kIOReturnSuccess;
+		if (!device)
+		{
+			return false;
+		}
+		return IOHIDDeviceSetReport((IOHIDDeviceRef)device, kIOHIDReportTypeFeature, buf.empty()?0:static_cast<uint8_t>(buf.at(0)), (uint8_t*)buf.data(), buf.size()) == kIOReturnSuccess;
 #else
-                return false;
+		return false;
 #endif
-        }
+	}
 
 #if SOUP_WINDOWS
 	void hwHid::kickOffRead() noexcept
@@ -1042,25 +1042,25 @@ NAMESPACE_SOUP
 
 		return result;
 #elif SOUP_LINUX
-                const auto rawdesc = string::fromFile(this->path + "/device/report_descriptor");
-                return HidReportDescriptor::parse(rawdesc.data(), rawdesc.size());
+		const auto rawdesc = string::fromFile(this->path + "/device/report_descriptor");
+		return HidReportDescriptor::parse(rawdesc.data(), rawdesc.size());
 #elif SOUP_MACOS
-                if (!device)
-                {
-                        return {};
-                }
-                if (CFTypeRef desc = IOHIDDeviceGetProperty((IOHIDDeviceRef)device, CFSTR(kIOHIDReportDescriptorKey)))
-                {
-                        if (CFGetTypeID(desc) == CFDataGetTypeID())
-                        {
-                                const UInt8* data = CFDataGetBytePtr((CFDataRef)desc);
-                                CFIndex len = CFDataGetLength((CFDataRef)desc);
-                                return HidReportDescriptor::parse((const char*)data, len);
-                        }
-                }
-                return {};
+		if (!device)
+		{
+			return {};
+		}
+		if (CFTypeRef desc = IOHIDDeviceGetProperty((IOHIDDeviceRef)device, CFSTR(kIOHIDReportDescriptorKey)))
+		{
+			if (CFGetTypeID(desc) == CFDataGetTypeID())
+			{
+				const UInt8* data = CFDataGetBytePtr((CFDataRef)desc);
+				CFIndex len = CFDataGetLength((CFDataRef)desc);
+				return HidReportDescriptor::parse((const char*)data, len);
+			}
+		}
+		return {};
 #else
-                return {};
+		return {};
 #endif
-        }
+	}
 }

--- a/soup/hwHid.cpp
+++ b/soup/hwHid.cpp
@@ -520,16 +520,7 @@ NAMESPACE_SOUP
 			}
 			HidD_FreePreparsedData(pp_data);
 		}
-#elif SOUP_LINUX
-		if (report_id == 0)
-		{
-			ret = report_ids.empty();
-		}
-		else
-		{
-			ret = report_ids.count(report_id) != 0;
-		}
-#elif SOUP_MACOS
+#else
 		if (report_id == 0)
 		{
 			ret = report_ids.empty();
@@ -625,14 +616,7 @@ NAMESPACE_SOUP
 			out_report_id = read_buffer.at(0);
 			read_buffer.erase(0, 1);
 		}
-#elif SOUP_LINUX
-		SOUP_UNUSED(receiveReport());
-		if (!report_ids.empty() && !read_buffer.empty())
-		{
-			out_report_id = read_buffer.at(0);
-			read_buffer.erase(0, 1);
-		}
-#elif SOUP_MACOS
+#else
 		SOUP_UNUSED(receiveReport());
 		if (!report_ids.empty() && !read_buffer.empty())
 		{
@@ -662,13 +646,7 @@ NAMESPACE_SOUP
 			pending_read = 0;
 		}
 		read_buffer.resize(bytes_read);
-#elif SOUP_LINUX
-		SOUP_UNUSED(receiveReport());
-		if (report_ids.empty())
-		{
-			read_buffer.insert_front(1, 0);
-		}
-#elif SOUP_MACOS
+#else
 		SOUP_UNUSED(receiveReport());
 		if (report_ids.empty())
 		{
@@ -687,15 +665,7 @@ NAMESPACE_SOUP
 		{
 			read_buffer.erase(0, 1);
 		}
-#elif SOUP_LINUX
-		SOUP_UNUSED(receiveReport());
-		if (input_report_byte_length != 0
-			&& !report_ids.empty()
-			)
-		{
-			read_buffer.erase(0, 1);
-		}
-#elif SOUP_MACOS
+#else
 		SOUP_UNUSED(receiveReport());
 		if (input_report_byte_length != 0
 			&& !report_ids.empty()

--- a/soup/hwHid.hpp
+++ b/soup/hwHid.hpp
@@ -6,11 +6,18 @@
 #include <string>
 #if !SOUP_WINDOWS
 #include <unordered_set>
+#include <pthread.h>
 #endif
 #include <vector>
 
 #include "Buffer.hpp"
+#if SOUP_MACOS
+#include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/hid/IOHIDManager.h>
+#endif
+#if !SOUP_MACOS
 #include "HandleRaii.hpp"
+#endif
 #include "HidReportDescriptor.hpp"
 
 NAMESPACE_SOUP
@@ -35,17 +42,21 @@ NAMESPACE_SOUP
 		DWORD bytes_read{};
 		OVERLAPPED read_overlapped{};
 #else
-		std::unordered_set<uint8_t> report_ids{};
-		std::string manufacturer_name;
-		std::string product_name;
-		std::string serial_number;
-		pthread_t read_thrd;
-		bool reading = false;
+                std::unordered_set<uint8_t> report_ids{};
+                std::string manufacturer_name;
+                std::string product_name;
+                std::string serial_number;
+                pthread_t read_thrd;
+                bool reading = false;
 #endif
 
-	private:
-		HandleRaii handle;
-		Buffer<> read_buffer;
+        private:
+#if SOUP_MACOS
+                void* device = nullptr; // IOHIDDeviceRef
+#else
+                HandleRaii handle;
+#endif
+                Buffer<> read_buffer;
 
 	public:
 		[[nodiscard]] static std::vector<hwHid> getAll();
@@ -83,10 +94,12 @@ NAMESPACE_SOUP
 		{
 #if SOUP_WINDOWS
 			return true;
+#elif SOUP_MACOS
+                        return device != nullptr;
 #else
-			return handle.isValid();
+                        return handle.isValid();
 #endif
-		}
+                }
 
 		[[nodiscard]] bool isBluetooth() const noexcept { return is_bluetooth; }
 		[[nodiscard]] bool hasReportId(uint8_t report_id) const noexcept;
@@ -101,14 +114,30 @@ NAMESPACE_SOUP
 		void receiveFeatureReport(Buffer<>& buf) const;
 
 		bool sendReport(Buffer<>&& buf) const noexcept;
-		bool sendReport(const void* data, size_t size) const noexcept;
-		bool sendFeatureReport(Buffer<>&& buf) const noexcept;
+                bool sendReport(const void* data, size_t size) const noexcept;
+                bool sendFeatureReport(Buffer<>&& buf) const noexcept;
 
-		void reset() noexcept
-		{
-			path.clear();
-			handle.~HandleRaii();
-		}
+                void reset() noexcept
+                {
+                        path.clear();
+#if SOUP_MACOS
+                        if (device)
+                        {
+                                IOHIDDeviceClose((IOHIDDeviceRef)device, kIOHIDOptionsTypeNone);
+                                CFRelease((IOHIDDeviceRef)device);
+                                device = nullptr;
+                        }
+#else
+                        handle.~HandleRaii();
+#endif
+                }
+
+#if SOUP_MACOS
+                ~hwHid()
+                {
+                        reset();
+                }
+#endif
 
 	private:
 #if SOUP_WINDOWS

--- a/soup/hwHid.hpp
+++ b/soup/hwHid.hpp
@@ -24,95 +24,95 @@
 NAMESPACE_SOUP
 {
 	// A human interface device.
-        class hwHid
-        {
-        public:
-                hwHid() = default;
-                hwHid(const hwHid&) = delete;
-                hwHid& operator=(const hwHid&) = delete;
-                hwHid(hwHid&& other) noexcept
-                        : path(std::move(other.path))
-                        , vendor_id(other.vendor_id)
-                        , product_id(other.product_id)
-                        , usage_page(other.usage_page)
-                        , usage(other.usage)
-                        , input_report_byte_length(other.input_report_byte_length)
-                        , output_report_byte_length(other.output_report_byte_length)
-                        , feature_report_byte_length(other.feature_report_byte_length)
-                        , is_bluetooth(other.is_bluetooth)
+	class hwHid
+	{
+	public:
+		hwHid() = default;
+		hwHid(const hwHid&) = delete;
+		hwHid& operator=(const hwHid&) = delete;
+		hwHid(hwHid&& other) noexcept
+			: path(std::move(other.path))
+			, vendor_id(other.vendor_id)
+			, product_id(other.product_id)
+			, usage_page(other.usage_page)
+			, usage(other.usage)
+			, input_report_byte_length(other.input_report_byte_length)
+			, output_report_byte_length(other.output_report_byte_length)
+			, feature_report_byte_length(other.feature_report_byte_length)
+			, is_bluetooth(other.is_bluetooth)
 #if SOUP_WINDOWS
-                        , pending_read(other.pending_read)
-                        , disconnected(other.disconnected)
-                        , bytes_read(other.bytes_read)
-                        , read_overlapped(other.read_overlapped)
-                        , handle(std::move(other.handle))
+			, pending_read(other.pending_read)
+			, disconnected(other.disconnected)
+			, bytes_read(other.bytes_read)
+			, read_overlapped(other.read_overlapped)
+			, handle(std::move(other.handle))
 #else
-                        , report_ids(std::move(other.report_ids))
-                        , manufacturer_name(std::move(other.manufacturer_name))
-                        , product_name(std::move(other.product_name))
-                        , serial_number(std::move(other.serial_number))
-                        , read_thrd(other.read_thrd)
-                        , reading(other.reading)
+			, report_ids(std::move(other.report_ids))
+			, manufacturer_name(std::move(other.manufacturer_name))
+			, product_name(std::move(other.product_name))
+			, serial_number(std::move(other.serial_number))
+			, read_thrd(other.read_thrd)
+			, reading(other.reading)
 #if SOUP_MACOS
-                        , device(other.device)
+			, device(other.device)
 #else
-                        , handle(std::move(other.handle))
+			, handle(std::move(other.handle))
 #endif
 #endif
-                        , read_buffer(std::move(other.read_buffer))
-                {
+			, read_buffer(std::move(other.read_buffer))
+		{
 #if SOUP_MACOS
-                        other.device = nullptr;
+			other.device = nullptr;
 #endif
-                }
+		}
 
-                hwHid& operator=(hwHid&& other) noexcept
-                {
-                        if (this != &other)
-                        {
+		hwHid& operator=(hwHid&& other) noexcept
+		{
+			if (this != &other)
+			{
 #if SOUP_MACOS
-                                if (device)
-                                {
-                                        IOHIDDeviceClose((IOHIDDeviceRef)device, kIOHIDOptionsTypeNone);
-                                        CFRelease((IOHIDDeviceRef)device);
-                                }
-                                device = other.device;
-                                other.device = nullptr;
+				if (device)
+				{
+					IOHIDDeviceClose((IOHIDDeviceRef)device, kIOHIDOptionsTypeNone);
+					CFRelease((IOHIDDeviceRef)device);
+				}
+				device = other.device;
+				other.device = nullptr;
 #else
-                                handle = std::move(other.handle);
+				handle = std::move(other.handle);
 #endif
-                                path = std::move(other.path);
-                                vendor_id = other.vendor_id;
-                                product_id = other.product_id;
-                                usage_page = other.usage_page;
-                                usage = other.usage;
-                                input_report_byte_length = other.input_report_byte_length;
-                                output_report_byte_length = other.output_report_byte_length;
-                                feature_report_byte_length = other.feature_report_byte_length;
-                                is_bluetooth = other.is_bluetooth;
+				path = std::move(other.path);
+				vendor_id = other.vendor_id;
+				product_id = other.product_id;
+				usage_page = other.usage_page;
+				usage = other.usage;
+				input_report_byte_length = other.input_report_byte_length;
+				output_report_byte_length = other.output_report_byte_length;
+				feature_report_byte_length = other.feature_report_byte_length;
+				is_bluetooth = other.is_bluetooth;
 #if SOUP_WINDOWS
-                                pending_read = other.pending_read;
-                                disconnected = other.disconnected;
-                                bytes_read = other.bytes_read;
-                                read_overlapped = other.read_overlapped;
+				pending_read = other.pending_read;
+				disconnected = other.disconnected;
+				bytes_read = other.bytes_read;
+				read_overlapped = other.read_overlapped;
 #else
-                                report_ids = std::move(other.report_ids);
-                                manufacturer_name = std::move(other.manufacturer_name);
-                                product_name = std::move(other.product_name);
-                                serial_number = std::move(other.serial_number);
-                                read_thrd = other.read_thrd;
-                                reading = other.reading;
+				report_ids = std::move(other.report_ids);
+				manufacturer_name = std::move(other.manufacturer_name);
+				product_name = std::move(other.product_name);
+				serial_number = std::move(other.serial_number);
+				read_thrd = other.read_thrd;
+				reading = other.reading;
 #endif
-                                read_buffer = std::move(other.read_buffer);
-                        }
-                        return *this;
-                }
+				read_buffer = std::move(other.read_buffer);
+			}
+			return *this;
+		}
 
-                std::string path;
-                uint16_t vendor_id;
-                uint16_t product_id;
-                uint16_t usage_page;
-                uint16_t usage;
+		std::string path;
+		uint16_t vendor_id;
+		uint16_t product_id;
+		uint16_t usage_page;
+		uint16_t usage;
 		uint16_t input_report_byte_length; // including report id
 		uint16_t output_report_byte_length; // including report id
 		uint16_t feature_report_byte_length; // including report id
@@ -124,21 +124,21 @@ NAMESPACE_SOUP
 		DWORD bytes_read{};
 		OVERLAPPED read_overlapped{};
 #else
-                std::unordered_set<uint8_t> report_ids{};
-                std::string manufacturer_name;
-                std::string product_name;
-                std::string serial_number;
-                pthread_t read_thrd;
-                bool reading = false;
+		std::unordered_set<uint8_t> report_ids{};
+		std::string manufacturer_name;
+		std::string product_name;
+		std::string serial_number;
+		pthread_t read_thrd;
+		bool reading = false;
 #endif
 
-        private:
+	private:
 #if SOUP_MACOS
-                void* device = nullptr; // IOHIDDeviceRef
+		void* device = nullptr; // IOHIDDeviceRef
 #else
-                HandleRaii handle;
+		HandleRaii handle;
 #endif
-                Buffer<> read_buffer;
+		Buffer<> read_buffer;
 
 	public:
 		[[nodiscard]] static std::vector<hwHid> getAll();
@@ -177,11 +177,11 @@ NAMESPACE_SOUP
 #if SOUP_WINDOWS
 			return true;
 #elif SOUP_MACOS
-                        return device != nullptr;
+			return device != nullptr;
 #else
-                        return handle.isValid();
+			return handle.isValid();
 #endif
-                }
+		}
 
 		[[nodiscard]] bool isBluetooth() const noexcept { return is_bluetooth; }
 		[[nodiscard]] bool hasReportId(uint8_t report_id) const noexcept;
@@ -196,29 +196,29 @@ NAMESPACE_SOUP
 		void receiveFeatureReport(Buffer<>& buf) const;
 
 		bool sendReport(Buffer<>&& buf) const noexcept;
-                bool sendReport(const void* data, size_t size) const noexcept;
-                bool sendFeatureReport(Buffer<>&& buf) const noexcept;
+		bool sendReport(const void* data, size_t size) const noexcept;
+		bool sendFeatureReport(Buffer<>&& buf) const noexcept;
 
-                void reset() noexcept
-                {
-                        path.clear();
+		void reset() noexcept
+		{
+			path.clear();
 #if SOUP_MACOS
-                        if (device)
-                        {
-                                IOHIDDeviceClose((IOHIDDeviceRef)device, kIOHIDOptionsTypeNone);
-                                CFRelease((IOHIDDeviceRef)device);
-                                device = nullptr;
-                        }
+			if (device)
+			{
+				IOHIDDeviceClose((IOHIDDeviceRef)device, kIOHIDOptionsTypeNone);
+				CFRelease((IOHIDDeviceRef)device);
+				device = nullptr;
+			}
 #else
-                        handle = HandleRaii();
+			handle = HandleRaii();
 #endif
-                }
+		}
 
 #if SOUP_MACOS
-                ~hwHid()
-                {
-                        reset();
-                }
+		~hwHid()
+		{
+			reset();
+		}
 #endif
 
 	private:

--- a/soup/hwHid.hpp
+++ b/soup/hwHid.hpp
@@ -9,6 +9,7 @@
 #include <pthread.h>
 #endif
 #include <vector>
+#include <utility>
 
 #include "Buffer.hpp"
 #if SOUP_MACOS
@@ -23,14 +24,95 @@
 NAMESPACE_SOUP
 {
 	// A human interface device.
-	class hwHid
-	{
-	public:
-		std::string path;
-		uint16_t vendor_id;
-		uint16_t product_id;
-		uint16_t usage_page;
-		uint16_t usage;
+        class hwHid
+        {
+        public:
+                hwHid() = default;
+                hwHid(const hwHid&) = delete;
+                hwHid& operator=(const hwHid&) = delete;
+                hwHid(hwHid&& other) noexcept
+                        : path(std::move(other.path))
+                        , vendor_id(other.vendor_id)
+                        , product_id(other.product_id)
+                        , usage_page(other.usage_page)
+                        , usage(other.usage)
+                        , input_report_byte_length(other.input_report_byte_length)
+                        , output_report_byte_length(other.output_report_byte_length)
+                        , feature_report_byte_length(other.feature_report_byte_length)
+                        , is_bluetooth(other.is_bluetooth)
+#if SOUP_WINDOWS
+                        , pending_read(other.pending_read)
+                        , disconnected(other.disconnected)
+                        , bytes_read(other.bytes_read)
+                        , read_overlapped(other.read_overlapped)
+                        , handle(std::move(other.handle))
+#else
+                        , report_ids(std::move(other.report_ids))
+                        , manufacturer_name(std::move(other.manufacturer_name))
+                        , product_name(std::move(other.product_name))
+                        , serial_number(std::move(other.serial_number))
+                        , read_thrd(other.read_thrd)
+                        , reading(other.reading)
+#if SOUP_MACOS
+                        , device(other.device)
+#else
+                        , handle(std::move(other.handle))
+#endif
+#endif
+                        , read_buffer(std::move(other.read_buffer))
+                {
+#if SOUP_MACOS
+                        other.device = nullptr;
+#endif
+                }
+
+                hwHid& operator=(hwHid&& other) noexcept
+                {
+                        if (this != &other)
+                        {
+#if SOUP_MACOS
+                                if (device)
+                                {
+                                        IOHIDDeviceClose((IOHIDDeviceRef)device, kIOHIDOptionsTypeNone);
+                                        CFRelease((IOHIDDeviceRef)device);
+                                }
+                                device = other.device;
+                                other.device = nullptr;
+#else
+                                handle = std::move(other.handle);
+#endif
+                                path = std::move(other.path);
+                                vendor_id = other.vendor_id;
+                                product_id = other.product_id;
+                                usage_page = other.usage_page;
+                                usage = other.usage;
+                                input_report_byte_length = other.input_report_byte_length;
+                                output_report_byte_length = other.output_report_byte_length;
+                                feature_report_byte_length = other.feature_report_byte_length;
+                                is_bluetooth = other.is_bluetooth;
+#if SOUP_WINDOWS
+                                pending_read = other.pending_read;
+                                disconnected = other.disconnected;
+                                bytes_read = other.bytes_read;
+                                read_overlapped = other.read_overlapped;
+#else
+                                report_ids = std::move(other.report_ids);
+                                manufacturer_name = std::move(other.manufacturer_name);
+                                product_name = std::move(other.product_name);
+                                serial_number = std::move(other.serial_number);
+                                read_thrd = other.read_thrd;
+                                reading = other.reading;
+#endif
+                                read_buffer = std::move(other.read_buffer);
+                        }
+                        return *this;
+                }
+
+                std::string path;
+                uint16_t vendor_id;
+                uint16_t product_id;
+                uint16_t usage_page;
+                uint16_t usage;
 		uint16_t input_report_byte_length; // including report id
 		uint16_t output_report_byte_length; // including report id
 		uint16_t feature_report_byte_length; // including report id
@@ -128,7 +210,7 @@ NAMESPACE_SOUP
                                 device = nullptr;
                         }
 #else
-                        handle.~HandleRaii();
+                        handle = HandleRaii();
 #endif
                 }
 


### PR DESCRIPTION
## Summary
- Extend `hwHid` with macOS-specific support using IOKit
- Handle device enumeration and HID report I/O on macOS

## Testing
- `php build_lib.php`

------
https://chatgpt.com/codex/tasks/task_e_68afd73d51a8832581b35fc7f6182aa1