### PR TITLE
Generate bindings as .dylib instead of .so on MacOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,7 +113,7 @@ jobs:
           path: |
             CLI/soup
             libsoup.a
-            libsoupbindings.so
+            libsoupbindings.dylib
 
   macos-14:
     runs-on: macos-14
@@ -141,7 +141,7 @@ jobs:
           path: |
             CLI/soup
             libsoup.a
-            libsoupbindings.so
+            libsoupbindings.dylib
 
   windows-latest:
     runs-on: windows-latest

--- a/build_lib.php
+++ b/build_lib.php
@@ -37,16 +37,27 @@ $libname = "libsoup.a";
 $dllname = "libsoupbindings.so";
 if (defined("PHP_WINDOWS_VERSION_MAJOR"))
 {
-	$archiver = "llvm-ar";
-	$libname = "soup.lib";
-	$dllname = "soupbindings.dll";
+        $archiver = "llvm-ar";
+        $libname = "soup.lib";
+        $dllname = "soupbindings.dll";
+}
+else if (PHP_OS_FAMILY == "Darwin")
+{
+        $dllname = "libsoupbindings.dylib";
 }
 passthru("$archiver rc $libname ".join(" ", $objects));
 
 if (file_exists("bin/int/soup.o"))
 {
-	echo "Linking shared lib...\n";
-	passthru("$clanglink -o $dllname --shared bin/int/soup.o ".join(" ", $objects));
+        echo "Linking shared lib...\n";
+        if (PHP_OS_FAMILY == "Darwin")
+        {
+                passthru("$clanglink -o $dllname -dynamiclib bin/int/soup.o ".join(" ", $objects));
+        }
+        else
+        {
+                passthru("$clanglink -o $dllname --shared bin/int/soup.o ".join(" ", $objects));
+        }
 }
 
 chdir($cd);

--- a/build_lib.php
+++ b/build_lib.php
@@ -37,27 +37,27 @@ $libname = "libsoup.a";
 $dllname = "libsoupbindings.so";
 if (defined("PHP_WINDOWS_VERSION_MAJOR"))
 {
-        $archiver = "llvm-ar";
-        $libname = "soup.lib";
-        $dllname = "soupbindings.dll";
+	$archiver = "llvm-ar";
+	$libname = "soup.lib";
+	$dllname = "soupbindings.dll";
 }
 else if (PHP_OS_FAMILY == "Darwin")
 {
-        $dllname = "libsoupbindings.dylib";
+	$dllname = "libsoupbindings.dylib";
 }
 passthru("$archiver rc $libname ".join(" ", $objects));
 
 if (file_exists("bin/int/soup.o"))
 {
-        echo "Linking shared lib...\n";
-        if (PHP_OS_FAMILY == "Darwin")
-        {
-                passthru("$clanglink -o $dllname -dynamiclib bin/int/soup.o ".join(" ", $objects));
-        }
-        else
-        {
-                passthru("$clanglink -o $dllname --shared bin/int/soup.o ".join(" ", $objects));
-        }
+	echo "Linking shared lib...\n";
+	if (PHP_OS_FAMILY == "Darwin")
+	{
+		passthru("$clanglink -o $dllname -dynamiclib bin/int/soup.o ".join(" ", $objects));
+	}
+	else
+	{
+		passthru("$clanglink -o $dllname --shared bin/int/soup.o ".join(" ", $objects));
+	}
 }
 
 chdir($cd);


### PR DESCRIPTION
## Summary
- Use `.dylib` extension for macOS builds
- Link shared library with `-dynamiclib` on macOS

## Testing
- `php -l build_lib.php`
- `php build_lib.php` *(fails: compilation aborted after partial progress)*

------
https://chatgpt.com/codex/tasks/task_e_68b3da8d06ac832592e80448b52560ec