### PR TITLE
Add dedicated reader thread for macOS HID

### DIFF
--- a/soup/hwHid.cpp
+++ b/soup/hwHid.cpp
@@ -644,18 +644,18 @@ NAMESPACE_SOUP
 			read_buffer.insert_front(1, 0);
 		}
 #elif SOUP_MACOS
-                if (!registered_callback)
-                {
-                        kickOffRead();
-                }
-                while (!got_a_report.load(std::memory_order_acquire))
-                {
-                        os::sleep(1);
-                }
-                got_a_report.store(false, std::memory_order_release);
+		if (!registered_callback)
+		{
+			kickOffRead();
+		}
+		while (!got_a_report.load(std::memory_order_acquire))
+		{
+			os::sleep(1);
+		}
+		got_a_report.store(false, std::memory_order_release);
 #endif
-                return read_buffer;
-        }
+		return read_buffer;
+	}
 
 	// URB_INTERRUPT in
 	const Buffer<>& hwHid::receiveReportWithoutReportId() noexcept
@@ -821,28 +821,28 @@ NAMESPACE_SOUP
 		}
 	}
 #elif SOUP_MACOS
-        void hwHid::kickOffRead() noexcept
-        {
-                if (device && !registered_callback)
-                {
-                        registered_callback = true;
-                        IOHIDDeviceRegisterInputReportCallback((IOHIDDeviceRef)device, read_buffer.data(), read_buffer.capacity(), [](void* context, IOReturn result, void* sender, IOHIDReportType type, uint32_t reportID, uint8_t* report, CFIndex reportLength)
-                        {
-                                auto* self = static_cast<hwHid*>(context);
-                                self->read_buffer.resize(reportLength);
-                                self->read_buffer.insert_front(1, reportID);
-                                self->got_a_report.store(true, std::memory_order_release);
-                        }, this);
-                        pthread_create(&read_thrd, nullptr, [](void* ctx) -> void*
-                        {
-                                auto* self = static_cast<hwHid*>(ctx);
-                                self->run_loop = CFRunLoopGetCurrent();
-                                IOHIDDeviceScheduleWithRunLoop((IOHIDDeviceRef)self->device, self->run_loop, kCFRunLoopDefaultMode);
-                                CFRunLoopRun();
-                                return nullptr;
-                        }, this);
-                }
-        }
+	void hwHid::kickOffRead() noexcept
+	{
+		if (device && !registered_callback)
+		{
+			registered_callback = true;
+			IOHIDDeviceRegisterInputReportCallback((IOHIDDeviceRef)device, read_buffer.data(), read_buffer.capacity(), [](void* context, IOReturn result, void* sender, IOHIDReportType type, uint32_t reportID, uint8_t* report, CFIndex reportLength)
+			{
+				auto* self = static_cast<hwHid*>(context);
+				self->read_buffer.resize(reportLength);
+				self->read_buffer.insert_front(1, reportID);
+				self->got_a_report.store(true, std::memory_order_release);
+			}, this);
+			pthread_create(&read_thrd, nullptr, [](void* ctx) -> void*
+			{
+				auto* self = static_cast<hwHid*>(ctx);
+				self->run_loop = CFRunLoopGetCurrent();
+				IOHIDDeviceScheduleWithRunLoop((IOHIDDeviceRef)self->device, self->run_loop, kCFRunLoopDefaultMode);
+				CFRunLoopRun();
+				return nullptr;
+			}, this);
+		}
+	}
 #endif
 
 #if SOUP_WINDOWS

--- a/soup/hwHid.cpp
+++ b/soup/hwHid.cpp
@@ -58,6 +58,7 @@ using udev_device_get_sysattr_value_t = const char*(*)(udev_device*, const char*
 #include <IOKit/hid/IOHIDManager.h>
 #include <IOKit/hid/IOHIDKeys.h>
 #include <IOKit/IOKitLib.h>
+#include "os.hpp"
 #endif
 
 NAMESPACE_SOUP
@@ -643,18 +644,18 @@ NAMESPACE_SOUP
 			read_buffer.insert_front(1, 0);
 		}
 #elif SOUP_MACOS
-		if (!registered_callback)
-		{
-			kickOffRead();
-		}
-		while (!got_a_report)
-		{
-			CFRunLoopRunInMode(kCFRunLoopDefaultMode, 0.001, true);
-		}
-		got_a_report = false;
+                if (!registered_callback)
+                {
+                        kickOffRead();
+                }
+                while (!got_a_report.load(std::memory_order_acquire))
+                {
+                        os::sleep(1);
+                }
+                got_a_report.store(false, std::memory_order_release);
 #endif
-		return read_buffer;
-	}
+                return read_buffer;
+        }
 
 	// URB_INTERRUPT in
 	const Buffer<>& hwHid::receiveReportWithoutReportId() noexcept
@@ -820,20 +821,28 @@ NAMESPACE_SOUP
 		}
 	}
 #elif SOUP_MACOS
-	void hwHid::kickOffRead() noexcept
-	{
-		if (device)
-		{
-			registered_callback = true;
-			IOHIDDeviceRegisterInputReportCallback((IOHIDDeviceRef)device, read_buffer.data(), read_buffer.capacity(), [](void* context, IOReturn result, void* sender, IOHIDReportType type, uint32_t reportID, uint8_t* report, CFIndex reportLength)
-			{
-				static_cast<hwHid*>(context)->read_buffer.resize(reportLength);
-				static_cast<hwHid*>(context)->read_buffer.insert_front(1, reportID);
-				static_cast<hwHid*>(context)->got_a_report = true;
-			}, this);
-			IOHIDDeviceScheduleWithRunLoop((IOHIDDeviceRef)device, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode); // Schedule with the current run loop so that callbacks are delivered
-		}
-	}
+        void hwHid::kickOffRead() noexcept
+        {
+                if (device && !registered_callback)
+                {
+                        registered_callback = true;
+                        IOHIDDeviceRegisterInputReportCallback((IOHIDDeviceRef)device, read_buffer.data(), read_buffer.capacity(), [](void* context, IOReturn result, void* sender, IOHIDReportType type, uint32_t reportID, uint8_t* report, CFIndex reportLength)
+                        {
+                                auto* self = static_cast<hwHid*>(context);
+                                self->read_buffer.resize(reportLength);
+                                self->read_buffer.insert_front(1, reportID);
+                                self->got_a_report.store(true, std::memory_order_release);
+                        }, this);
+                        pthread_create(&read_thrd, nullptr, [](void* ctx) -> void*
+                        {
+                                auto* self = static_cast<hwHid*>(ctx);
+                                self->run_loop = CFRunLoopGetCurrent();
+                                IOHIDDeviceScheduleWithRunLoop((IOHIDDeviceRef)self->device, self->run_loop, kCFRunLoopDefaultMode);
+                                CFRunLoopRun();
+                                return nullptr;
+                        }, this);
+                }
+        }
 #endif
 
 #if SOUP_WINDOWS

--- a/soup/hwHid.hpp
+++ b/soup/hwHid.hpp
@@ -10,6 +10,7 @@
 #endif
 #include <vector>
 #include <utility>
+#include <atomic>
 
 #include "Buffer.hpp"
 #if SOUP_MACOS
@@ -46,12 +47,17 @@ NAMESPACE_SOUP
 					CFRelease((IOHIDDeviceRef)device);
 				}
 				device = other.device;
-				other.device = nullptr;
-				if (other.registered_callback)
-				{
-					uint8_t dummy;
-					IOHIDDeviceRegisterInputReportCallback((IOHIDDeviceRef)device, &dummy, 0, nullptr, nullptr);
-				}
+                                other.device = nullptr;
+                                if (other.registered_callback)
+                                {
+                                        uint8_t dummy;
+                                        IOHIDDeviceRegisterInputReportCallback((IOHIDDeviceRef)device, &dummy, 0, nullptr, nullptr);
+                                }
+                                run_loop = other.run_loop;
+                                read_thrd = other.read_thrd;
+                                got_a_report.store(other.got_a_report.load());
+                                other.run_loop = nullptr;
+                                other.read_thrd = {};
 #else
 				handle = std::move(other.handle);
 #endif
@@ -80,9 +86,9 @@ NAMESPACE_SOUP
 	#endif
 #endif
 				read_buffer = std::move(other.read_buffer);
-	#if SOUP_MACOS
-				got_a_report = other.got_a_report;
-	#endif
+#if SOUP_MACOS
+                                got_a_report.store(other.got_a_report.load());
+#endif
 			}
 			return *this;
 		}
@@ -104,24 +110,29 @@ NAMESPACE_SOUP
 		OVERLAPPED read_overlapped{};
 #else
 		std::unordered_set<uint8_t> report_ids{};
-		std::string manufacturer_name;
-		std::string product_name;
-		std::string serial_number;
-	#if !SOUP_MACOS
-		pthread_t read_thrd;
-		bool reading = false;
-	#endif
+                std::string manufacturer_name;
+                std::string product_name;
+                std::string serial_number;
+#if SOUP_MACOS
+                // Dedicated reader thread run loop
+                // Managed internally for macOS
+#else
+                pthread_t read_thrd;
+                bool reading = false;
+#endif
 #endif
 
 	private:
 #if SOUP_MACOS
-		void* device = nullptr; // IOHIDDeviceRef
-		bool registered_callback = false;
-		bool got_a_report = false;
+                void* device = nullptr; // IOHIDDeviceRef
+                bool registered_callback = false;
+                std::atomic_bool got_a_report{false};
+                CFRunLoopRef run_loop = nullptr;
+                pthread_t read_thrd{};
 #else
-		HandleRaii handle;
+                HandleRaii handle;
 #endif
-		Buffer<> read_buffer;
+                Buffer<> read_buffer;
 
 	public:
 		[[nodiscard]] static std::vector<hwHid> getAll();
@@ -186,21 +197,28 @@ NAMESPACE_SOUP
 		{
 			path.clear();
 #if SOUP_MACOS
-			if (device)
-			{
-				if (registered_callback)
-				{
-					IOHIDDeviceUnscheduleFromRunLoop((IOHIDDeviceRef)device, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
-					registered_callback = false;
-				}
-				IOHIDDeviceClose((IOHIDDeviceRef)device, kIOHIDOptionsTypeNone);
-				CFRelease((IOHIDDeviceRef)device);
-				device = nullptr;
-			}
+                        if (device)
+                        {
+                                if (registered_callback && run_loop)
+                                {
+                                        IOHIDDeviceUnscheduleFromRunLoop((IOHIDDeviceRef)device, run_loop, kCFRunLoopDefaultMode);
+                                        registered_callback = false;
+                                }
+                                IOHIDDeviceClose((IOHIDDeviceRef)device, kIOHIDOptionsTypeNone);
+                                CFRelease((IOHIDDeviceRef)device);
+                                device = nullptr;
+                        }
+                        if (run_loop)
+                        {
+                                CFRunLoopStop(run_loop);
+                                pthread_join(read_thrd, nullptr);
+                                run_loop = nullptr;
+                                read_thrd = {};
+                        }
 #else
-			handle = HandleRaii();
+                        handle = HandleRaii();
 #endif
-		}
+                }
 
 #if SOUP_MACOS
 		~hwHid()

--- a/soup/hwHid.hpp
+++ b/soup/hwHid.hpp
@@ -47,17 +47,17 @@ NAMESPACE_SOUP
 					CFRelease((IOHIDDeviceRef)device);
 				}
 				device = other.device;
-                                other.device = nullptr;
-                                if (other.registered_callback)
-                                {
-                                        uint8_t dummy;
-                                        IOHIDDeviceRegisterInputReportCallback((IOHIDDeviceRef)device, &dummy, 0, nullptr, nullptr);
-                                }
-                                run_loop = other.run_loop;
-                                read_thrd = other.read_thrd;
-                                got_a_report.store(other.got_a_report.load());
-                                other.run_loop = nullptr;
-                                other.read_thrd = {};
+				other.device = nullptr;
+				if (other.registered_callback)
+				{
+					uint8_t dummy;
+					IOHIDDeviceRegisterInputReportCallback((IOHIDDeviceRef)device, &dummy, 0, nullptr, nullptr);
+				}
+				run_loop = other.run_loop;
+				read_thrd = other.read_thrd;
+				got_a_report.store(other.got_a_report.load());
+				other.run_loop = nullptr;
+				other.read_thrd = {};
 #else
 				handle = std::move(other.handle);
 #endif
@@ -87,7 +87,7 @@ NAMESPACE_SOUP
 #endif
 				read_buffer = std::move(other.read_buffer);
 #if SOUP_MACOS
-                                got_a_report.store(other.got_a_report.load());
+				got_a_report.store(other.got_a_report.load());
 #endif
 			}
 			return *this;
@@ -110,29 +110,29 @@ NAMESPACE_SOUP
 		OVERLAPPED read_overlapped{};
 #else
 		std::unordered_set<uint8_t> report_ids{};
-                std::string manufacturer_name;
-                std::string product_name;
-                std::string serial_number;
+		std::string manufacturer_name;
+		std::string product_name;
+		std::string serial_number;
 #if SOUP_MACOS
-                // Dedicated reader thread run loop
-                // Managed internally for macOS
+		// Dedicated reader thread run loop
+		// Managed internally for macOS
 #else
-                pthread_t read_thrd;
-                bool reading = false;
+		pthread_t read_thrd;
+		bool reading = false;
 #endif
 #endif
 
 	private:
 #if SOUP_MACOS
-                void* device = nullptr; // IOHIDDeviceRef
-                bool registered_callback = false;
-                std::atomic_bool got_a_report{false};
-                CFRunLoopRef run_loop = nullptr;
-                pthread_t read_thrd{};
+		void* device = nullptr; // IOHIDDeviceRef
+		bool registered_callback = false;
+		std::atomic_bool got_a_report{false};
+		CFRunLoopRef run_loop = nullptr;
+		pthread_t read_thrd{};
 #else
-                HandleRaii handle;
+		HandleRaii handle;
 #endif
-                Buffer<> read_buffer;
+		Buffer<> read_buffer;
 
 	public:
 		[[nodiscard]] static std::vector<hwHid> getAll();
@@ -197,28 +197,28 @@ NAMESPACE_SOUP
 		{
 			path.clear();
 #if SOUP_MACOS
-                        if (device)
-                        {
-                                if (registered_callback && run_loop)
-                                {
-                                        IOHIDDeviceUnscheduleFromRunLoop((IOHIDDeviceRef)device, run_loop, kCFRunLoopDefaultMode);
-                                        registered_callback = false;
-                                }
-                                IOHIDDeviceClose((IOHIDDeviceRef)device, kIOHIDOptionsTypeNone);
-                                CFRelease((IOHIDDeviceRef)device);
-                                device = nullptr;
-                        }
-                        if (run_loop)
-                        {
-                                CFRunLoopStop(run_loop);
-                                pthread_join(read_thrd, nullptr);
-                                run_loop = nullptr;
-                                read_thrd = {};
-                        }
+			if (device)
+			{
+				if (registered_callback && run_loop)
+				{
+					IOHIDDeviceUnscheduleFromRunLoop((IOHIDDeviceRef)device, run_loop, kCFRunLoopDefaultMode);
+					registered_callback = false;
+				}
+				IOHIDDeviceClose((IOHIDDeviceRef)device, kIOHIDOptionsTypeNone);
+				CFRelease((IOHIDDeviceRef)device);
+				device = nullptr;
+			}
+			if (run_loop)
+			{
+				CFRunLoopStop(run_loop);
+				pthread_join(read_thrd, nullptr);
+				run_loop = nullptr;
+				read_thrd = {};
+			}
 #else
-                        handle = HandleRaii();
+			handle = HandleRaii();
 #endif
-                }
+		}
 
 #if SOUP_MACOS
 		~hwHid()


### PR DESCRIPTION
## Summary
- Spawn a dedicated reader thread on macOS devices to handle HID input via run loop
- Use atomic flag and sleep loop to wait for reports without polling run loop
- Clean up macOS reader thread and run loop during reset

## Testing
- `php build_lib.php`

------
https://chatgpt.com/codex/tasks/task_e_68b7fa6268c083258f3517a3bb3b1932