### PR TITLE
Fix: Add UniquePtr.hpp include to Op.hpp

### DIFF
--- a/soup/Op.hpp
+++ b/soup/Op.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 
 #include "base.hpp"
+#include "UniquePtr.hpp"
 
 NAMESPACE_SOUP
 {


### PR DESCRIPTION
Op.hpp uses std::vector<UniquePtr<astNode>> but only had a forward declaration of UniquePtr. This caused template instantiation errors when compiling ParserState.cpp. Adding the full include fixes the compilation error when using clang.

This PR contains only this single fix.