### PR TITLE
16-bit interpretation of analog reports nuphy fix

### DIFF
--- a/soup/AnalogueKeyboard.cpp
+++ b/soup/AnalogueKeyboard.cpp
@@ -1006,9 +1006,11 @@ if (combined[i]) \
 			{
 				r.skip(1); // unknown, seems to be 0x10 in most cases
 				uint16_t scancode; r.u16_be(scancode);
-				r.skip(2); // fvalue * 800 (u16_be)
+				uint16_t fvalue_800; r.u16_be(fvalue_800); // fvalue * 800 (u16_be) - true 16bit value
 				r.skip(1); // unknown, seems to always be 0x00
-				uint8_t value; r.u8(value); // fvalue * 200
+				uint8_t value_8bit; r.u8(value_8bit); // fvalue * 200 (8-bit, ignored)
+				
+				uint8_t value = static_cast<uint8_t>(std::min(255u, (fvalue_800 * 255u) / 1600u));
 
 				Key sk;
 				SOUP_IF_UNLIKELY ((scancode >> 8) != 0)
@@ -1044,7 +1046,7 @@ if (combined[i]) \
 				{
 					keys.emplace_back(ActiveKey{
 						static_cast<Key>(i),
-						static_cast<float>(nuphy.buffer[i]) / 200.0f
+						static_cast<float>(nuphy.buffer[i]) / 255.0f
 					});
 				}
 			}


### PR DESCRIPTION
## Fix NuPhy analog value overflow causing travel distance to reset at 2.5mm           
  ### Problem                                                                         
  The analog travel distance calculation for NuPhy keyboards was using an 8-bit value
  (`fvalue * 200`) which overflows at 255. Since NuPhy keyboards have a 3.2mm total
  travel distance, the emulated travel would:
  - Go from 0% to 100% between 0mm and 2.5mm
  - Overflow and reset to 0% at 2.5mm
  - Go from 0% to 33% between 2.5mm and 3.2mm

  This created an incorrect "0→100→0→33" travel pattern instead of a smooth 0→100     
  progression.

  ### Solution
  Switch from the 8-bit truncated value to the full 16-bit value (`fvalue * 800`) that
   was being skipped in the protocol parsing. The 16-bit value is then properly       
  normalized to 255 by scaling it to the full range (1600):

  ```cpp
  uint8_t value = static_cast<uint8_t>(std::min(255u, (fvalue_800 * 255u) / 1600u));  

  Also updated the buffer interpretation to divide by 255 instead of 200 to match the 
  new normalized range.

  Changes

  - Read and use the 16-bit fvalue * 800 value instead of skipping it
  - Calculate proper 8-bit value from 16-bit source using correct scaling (÷1600)     
  - Update buffer value interpretation (÷255 instead of ÷200)

  Testing

  With this change, NuPhy keyboards now report smooth analog travel from 0% to 100%   
  across the full 3.2mm key press distance without any overflow resets.
  ```